### PR TITLE
Artifact book Shuffle when item is removed

### DIFF
--- a/src/MacroTools/Frames/Books/ArtifactSystem/ArtifactBook.cs
+++ b/src/MacroTools/Frames/Books/ArtifactSystem/ArtifactBook.cs
@@ -25,9 +25,7 @@ namespace MacroTools.Frames.Books.ArtifactSystem
       height, bottomButtonXOffset, bottomButtonYOffset)
     {
       ArtifactManager.ArtifactRegistered += ArtifactCreated;
-      var firstPage = AddPage();
-      firstPage.Visible = true;
-      AddAllArtifacts();
+      AddPagesAndArtifacts();
       BookTitle = "Artifacts";
       LauncherParent = BlzGetFrameByName("UpperButtonBarQuestsButton", 0);
       Position = new Point(0.4f, 0.38f);
@@ -41,7 +39,6 @@ namespace MacroTools.Frames.Books.ArtifactSystem
         AddPage();
         lastPage = Pages.Last();
       }
-
       lastPage.AddArtifact(artifact);
       _pagesByArtifact.Add(artifact, lastPage);
       artifact.Disposed += OnArtifactDisposed;
@@ -49,14 +46,33 @@ namespace MacroTools.Frames.Books.ArtifactSystem
 
     private void OnArtifactDisposed(object? sender, Artifact artifact)
     {
-      _pagesByArtifact[artifact].RemoveArtifact(artifact);
-      _pagesByArtifact.Remove(artifact);
+        ReRender();
+    }
+
+    private void ReRender()
+    {
+        foreach (var artifactbyPage in _pagesByArtifact)
+            artifactbyPage.Value.RemoveArtifact(artifactbyPage.Key);
+        _pagesByArtifact.Clear();
+
+        foreach (var page in Pages)
+            page.Dispose();
+        Pages.Clear();
+
+        AddPagesAndArtifacts();
+    }
+
+    private void AddPagesAndArtifacts()
+    {
+        var firstPage = AddPage();
+        firstPage.Visible = true;
+        AddAllArtifacts();
     }
 
     private void AddAllArtifacts()
     {
       foreach (var artifact in ArtifactManager.GetAllArtifacts())
-        AddArtifact(artifact);
+       AddArtifact(artifact);
     }
 
     private static void LoadToc(string tocFilePath)

--- a/src/MacroTools/Frames/Books/ArtifactSystem/ArtifactPage.cs
+++ b/src/MacroTools/Frames/Books/ArtifactSystem/ArtifactPage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using MacroTools.ArtifactSystem;
 
 namespace MacroTools.Frames.Books.ArtifactSystem

--- a/src/MacroTools/Frames/Books/Book.cs
+++ b/src/MacroTools/Frames/Books/Book.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
 
@@ -173,6 +174,13 @@ namespace MacroTools.Frames.Books
                return;
             Visible = true;
             _launcher.Visible = false;
+            foreach (var page in Pages)
+            {
+                page.Visible = false;
+            }
+            Pages.First().Visible = true;
+            _activePageIndex = 0;
+            RefreshNavigationButtonVisiblity();
          }
          catch (Exception ex)
          {

--- a/src/MacroTools/Frames/Books/Page.cs
+++ b/src/MacroTools/Frames/Books/Page.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using static War3Api.Common;
 
 namespace MacroTools.Frames.Books
@@ -44,12 +43,11 @@ namespace MacroTools.Frames.Books
     /// </summary>
     public int CardCount => Cards.Count;
     
-    private void PositionAllCards()
+    protected void PositionAllCards()
     {
       var i = 0;
       foreach (var card in Cards)
       {
-        Console.WriteLine(i);
         PositionFrameAtIndex(card, i);
         i++;
       }


### PR DESCRIPTION
Hi,

I've been playing the map for a while and since this repo is public I thought I'd try solving a couple open issues.

This attempts to solve issue #121 

All Artifact pages are redrawn whenever an artifact is removed. This ensure that there are no empty pages, no half full pages and no gaps within a page. So it should cover all cases. 

There aren't that many artifacts from what i've seen so even though this is probably not ideal performance wise I figured it wouldn't be that costly anyway.