### PR TITLE
attempt to solve issue #72

### DIFF
--- a/src/WarcraftLegacies.Source/Mechanics/Scourge/HelmOfDominationDropsWhenScourgeLeaves.cs
+++ b/src/WarcraftLegacies.Source/Mechanics/Scourge/HelmOfDominationDropsWhenScourgeLeaves.cs
@@ -1,22 +1,31 @@
-// using WarcraftLegacies.Source.Legends;
-// using WarcraftLegacies.Source.Setup;
-// using WarcraftLegacies.Source.Setup.FactionSetup;
-//
-// using static War3Api.Common;  using static MacroTools.GeneralHelpers;
-// {
-//   public class HelmOfDominationDropsWhenScourgeLeaves{
-//
-//     private static void Actions( ){
-//       if (GetTriggerFaction() == ScourgeSetup.FactionScourge && ArtifactSetup.ArtifactHelmofdomination.OwningUnit == LegendScourge.LegendLichking.Unit){
-//         SetItemPosition(ArtifactSetup.ArtifactHelmofdomination.Item, GetRectCenterX(gg_rct_LichKing), GetRectCenterY(gg_rct_LichKing));
-//       }
-//     }
-//
-//     public static void Setup( ){
-//       trigger trig = CreateTrigger();
-//       OnFactionGameLeave.register(trig);
-//       TriggerAddAction(trig,  Actions);
-//     }
-//
-//   }
-// }
+using WarcraftLegacies.Source.Setup.Legends;
+using WarcraftLegacies.Source.Setup;
+using WarcraftLegacies.Source.Setup.FactionSetup;
+using MacroTools.FactionSystem;
+using MacroTools.Extensions;
+using WCSharp.Shared.Data;
+
+/// <summary>
+///  When Scourge leaves the game, drop the Helm of Domination to an easily accessible position since the default position is hard to see.
+/// </summary>
+public class HelmOfDominationDropsWhenScourgeLeaves
+{
+    public static void Setup()
+    {
+        Faction.GameLeave += Faction_GameLeave;
+    }
+
+    private static void Faction_GameLeave(object? sender, Faction leavingFaction)
+    {
+        if (ArtifactSetup.ArtifactHelmofdomination == null || LegendScourge.LegendLichking?.Unit == null)
+            return;
+        
+        if (leavingFaction == ScourgeSetup.Scourge && ArtifactSetup.ArtifactHelmofdomination.OwningUnit == LegendScourge.LegendLichking.Unit)
+        {
+            var lichKingPosition = LegendScourge.LegendLichking.Unit.GetPosition();
+            LegendScourge.LegendLichking.Unit.DropAllItems();
+            ArtifactSetup.ArtifactHelmofdomination.Item.SetPosition(new Point(lichKingPosition.X - 55, lichKingPosition.Y + 30));// Move item in front of the LK 
+        }
+    }
+}
+

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/ScourgeSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/ScourgeSetup.cs
@@ -120,7 +120,9 @@ The Necropolis of Naxxramas is become the perfect weapon for the Scourge, but yo
       Scourge.AddPower(visionPower);
       
       Scourge.AddGoldMine(PreplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(-4939, 18803)));
-      
+
+      HelmOfDominationDropsWhenScourgeLeaves.Setup();
+
       FactionManager.Register(Scourge);
     }
   }


### PR DESCRIPTION
Dropping all LK items, then moving the item a more easily accessible spot.

I would have preferred to use `DropItem(item)` but I couldn't get that to work.
Since LK only has one item I hope it is okay to do it this way.

I am also unsure about the way I wired up the event. Haven't seen it done this way in any of the other Mechanics.  All of them use triggers but this worked in my tests.
 