### PR TITLE
Add Scepter of the Queen related quests to Warsong and Sentinels  #62

### DIFF
--- a/src/MacroTools/Extensions/RectExtensions.cs
+++ b/src/MacroTools/Extensions/RectExtensions.cs
@@ -1,0 +1,58 @@
+﻿using MacroTools.Wrappers;
+using static War3Api.Common;
+
+namespace MacroTools.Extensions
+{
+    /// <summary>
+    /// Provides a helpful set of extension methods for <see cref="rect"/>s.
+    /// </summary>
+    public static class RectExtensions
+    {
+        /// <summary>
+        /// Renders all units inside the specified area invulnerable/>
+        /// </summary>
+        /// <param name="area"></param>
+        public static void MakeUnitsInvulnerable(this rect area)
+        {
+            var shenGroup = CreateGroup();
+            GroupEnumUnitsInRect(shenGroup, area, null);
+            bool execute = true;
+            while (execute)
+            {
+                var unit = FirstOfGroup(shenGroup);
+                if (unit == null)
+                {
+                    execute = false;
+                    continue;
+                }
+                if (GetOwningPlayer(unit) == Player(GetPlayerNeutralPassive()))
+                {
+                    SetUnitInvulnerable(unit, true);
+                }
+                GroupRemoveUnit(shenGroup, unit);
+            }
+        }
+
+        /// <summary>
+        /// Changes the owner of all units inside the specified <paramref name="area"/> from <paramref name="owningPlayer"/> to <paramref name="newOwningPlayer"/> 
+        /// and renders all non-building units invisible.
+        /// </summary>
+        /// <param name="area"></param>
+        /// <param name="owningPlayer"></param>
+        /// <param name="newOwningPlayer"></param>
+        public static void ChangeUnitsOwningPlayer(this rect area, player owningPlayer, player newOwningPlayer)
+        {
+            foreach (var unit in new GroupWrapper().EnumUnitsInRect(area).EmptyToList())
+            {
+                if (unit.OwningPlayer() == owningPlayer)
+                {
+                    unit.SetOwner(newOwningPlayer);
+                    if (!IsUnitType(unit, UNIT_TYPE_STRUCTURE))
+                    {
+                        unit.Show(false);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/MacroTools/Extensions/RectExtensions.cs
+++ b/src/MacroTools/Extensions/RectExtensions.cs
@@ -1,20 +1,25 @@
 ﻿using MacroTools.Wrappers;
+using System.Collections.Generic;
 using static War3Api.Common;
 
 namespace MacroTools.Extensions
 {
     /// <summary>
-    /// Provides a helpful set of extension methods for <see cref="rect"/>s.
+    /// Provides a helpful set of extension methods for native Warcraft 3 <see cref="rect"/>s.
     /// </summary>
     public static class RectExtensions
     {
         /// <summary>
-        /// Renders all units inside the specified area invulnerable/>
+        /// Renders all units inside the specified <paramref name="area"/> that belong to <paramref name="owningUnitsPlayer"/> invulnerable/>
         /// </summary>
         /// <param name="area"></param>
-        public static void MakeUnitsInvulnerable(this rect area)
-        {
+        /// <param name="owningUnitsPlayer"></param>
+        /// <returns>A list of all units found in the specified area that belong to <paramref name="owningUnitsPlayer"/></returns>
+        // Todo: Rename to something more sensible
+        public static List<unit> MakeUnitsInvulnerable(this rect area, player owningUnitsPlayer)
+        {        
             var shenGroup = CreateGroup();
+            List<unit> groupUnits = new();
             GroupEnumUnitsInRect(shenGroup, area, null);
             bool execute = true;
             while (execute)
@@ -25,12 +30,14 @@ namespace MacroTools.Extensions
                     execute = false;
                     continue;
                 }
-                if (GetOwningPlayer(unit) == Player(GetPlayerNeutralPassive()))
+                if (GetOwningPlayer(unit) == owningUnitsPlayer)
                 {
                     SetUnitInvulnerable(unit, true);
+                    groupUnits.Add(unit);
                 }
-                GroupRemoveUnit(shenGroup, unit);
+                GroupRemoveUnit(shenGroup, unit);               
             }
+            return groupUnits;
         }
 
         /// <summary>

--- a/src/MacroTools/FactionSystem/PlayerExtensions.cs
+++ b/src/MacroTools/FactionSystem/PlayerExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using MacroTools.Extensions;
 using MacroTools.Wrappers;
 using static War3Api.Common;
 
@@ -167,12 +169,30 @@ namespace MacroTools.FactionSystem
     {
       PlayerData.ByHandle(player).LumberIncome += value;
     }
-    
+
     internal static void SetControlPointCount(this player player, int value)
     {
       PlayerData.ByHandle(player).ControlPointCount = value;
     }
-    
+
+    /// <summary>
+    /// Changes the owner of all <paramref name="units"/> to <paramref name="newOwningPlayer"/> 
+    /// and renders all non-building units invisible.
+    /// </summary>
+    /// <param name="newOwningPlayer"></param>
+    /// <param name="units"></param>
+    public static void MakeUnitsOwner(this player newOwningPlayer, List<unit> units)
+    {
+        foreach (var unit in units)
+        {
+            unit.SetOwner(newOwningPlayer);
+            if (!IsUnitType(unit, UNIT_TYPE_STRUCTURE))
+            {
+                unit.Show(false);
+            }
+        }
+    }
+
     /// <summary>
     ///   Determines whether or not the player can see or use the specified ability.
     /// </summary>

--- a/src/WarcraftLegacies.Source/Quests/Sentinels/QuestScepterOfTheQueenSentinels.cs
+++ b/src/WarcraftLegacies.Source/Quests/Sentinels/QuestScepterOfTheQueenSentinels.cs
@@ -2,6 +2,7 @@
 using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
+using System.Collections.Generic;
 using WarcraftLegacies.Source.Setup;
 using WarcraftLegacies.Source.Setup.Legends;
 using WCSharp.Shared.Data;
@@ -9,42 +10,33 @@ using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Sentinels
 {
-    public class QuestScepterOfTheQueenSentinels : QuestData
+    public sealed class QuestScepterOfTheQueenSentinels : QuestData
     {
         public QuestScepterOfTheQueenSentinels(Rectangle area) : base("Return to the Fold", "Remnants of the ancient Highborne survive within the ruins of Dire Maul. If Stonemaul falls, it would be safe for them to come out.", "ReplaceableTextures\\CommandButtons\\BTNNagaWeaponUp2.blp")
         {
-            HighBourneArea = area;
+            _highBourneArea = area;
             AddObjective(new ObjectiveLegendNotPermanentlyDead(LegendSentinels.legendFeathermoon));
             AddObjective(new ObjectiveLegendDead(LegendWarsong.StonemaulKeep));
             AddObjective(new ObjectiveAnyUnitInRect(Regions.HighBourne, "Dire Maul", true));
-            ResearchId = FourCC("R020");
-            HighBourneArea.Rect.MakeUnitsInvulnerable();
+            ResearchId = Constants.UPGRADE_R02O_QUEST_COMPLETED_RETURN_TO_THE_FOLD_SENTINELS;
+           _highBourneAreaUnits = _highBourneArea.Rect.MakeUnitsInvulnerable(Player(GetPlayerNeutralPassive()));
         }
 
-        private Rectangle HighBourneArea { get; }
-        protected override string CompletionPopup => "The Shen'dralar, the Highborne survivors of the Sundering, swear allegiance to their fellow Night Elves. As a sign of their loyalty, they offer up an artifact they have guarded for thousands of years: the Scepter of the Queen.";
-        protected override string RewardDescription => "Gain the Scepter of the Queen and control of all units in Dire Maul";
+        private List<unit> _highBourneAreaUnits;
+        private Rectangle _highBourneArea { get; }
 
+        /// <inheritdoc/>
+        protected override string CompletionPopup => "The Shen'dralar, the Highborne survivors of the Sundering, swear allegiance to their fellow Night Elves. As a sign of their loyalty, they offer up an artifact they have guarded for thousands of years: the Scepter of the Queen.";
+
+        /// <inheritdoc/>
+        protected override string RewardDescription => "Gain the Scepter of the Queen and control of all units in Dire Maul";
+        /// <inheritdoc/>
         protected override void OnComplete(Faction whichFaction)
         {
-            ArtifactSetup.ArtifactScepterofthequeen?.Item.SetPosition(new Point(GetRectCenterX(HighBourneArea.Rect), GetRectCenterY(HighBourneArea.Rect)));
+            ArtifactSetup.ArtifactScepterofthequeen?.Item.SetPosition(_highBourneArea.Center);
             SetPlayerTechResearched(whichFaction.Player, ResearchId, 1);
             if (whichFaction.Player != null)
-                HighBourneArea.Rect.ChangeUnitsOwningPlayer(Player(GetPlayerNeutralPassive()), whichFaction.Player);
-        }
-
-        protected override void OnAdd(Faction whichFaction)
-        {
-            base.OnAdd(whichFaction);
-            whichFaction.ModObjectLimit(ResearchId, Faction.UNLIMITED);
-        }
-
-        protected override void OnFail(Faction whichFaction)
-        {
-            base.OnFail(whichFaction);
-            whichFaction.ModObjectLimit(ResearchId, -Faction.UNLIMITED);
-        }
-
-        
+                Player(GetPlayerNeutralPassive()).MakeUnitsOwner(_highBourneAreaUnits);
+        }        
     }
 }

--- a/src/WarcraftLegacies.Source/Quests/Sentinels/QuestScepterOfTheQueenSentinels.cs
+++ b/src/WarcraftLegacies.Source/Quests/Sentinels/QuestScepterOfTheQueenSentinels.cs
@@ -1,0 +1,50 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using MacroTools.QuestSystem;
+using MacroTools.QuestSystem.UtilityStructs;
+using WarcraftLegacies.Source.Setup;
+using WarcraftLegacies.Source.Setup.Legends;
+using WCSharp.Shared.Data;
+using static War3Api.Common;
+
+namespace WarcraftLegacies.Source.Quests.Sentinels
+{
+    public class QuestScepterOfTheQueenSentinels : QuestData
+    {
+        public QuestScepterOfTheQueenSentinels(Rectangle area) : base("Return to the Fold", "Remnants of the ancient Highborne survive within the ruins of Dire Maul. If Stonemaul falls, it would be safe for them to come out.", "ReplaceableTextures\\CommandButtons\\BTNNagaWeaponUp2.blp")
+        {
+            HighBourneArea = area;
+            AddObjective(new ObjectiveLegendNotPermanentlyDead(LegendSentinels.legendFeathermoon));
+            AddObjective(new ObjectiveLegendDead(LegendWarsong.StonemaulKeep));
+            AddObjective(new ObjectiveAnyUnitInRect(Regions.HighBourne, "Dire Maul", true));
+            ResearchId = FourCC("R020");
+            HighBourneArea.Rect.MakeUnitsInvulnerable();
+        }
+
+        private Rectangle HighBourneArea { get; }
+        protected override string CompletionPopup => "The Shen'dralar, the Highborne survivors of the Sundering, swear allegiance to their fellow Night Elves. As a sign of their loyalty, they offer up an artifact they have guarded for thousands of years: the Scepter of the Queen.";
+        protected override string RewardDescription => "Gain the Scepter of the Queen and control of all units in Dire Maul";
+
+        protected override void OnComplete(Faction whichFaction)
+        {
+            ArtifactSetup.ArtifactScepterofthequeen?.Item.SetPosition(new Point(GetRectCenterX(HighBourneArea.Rect), GetRectCenterY(HighBourneArea.Rect)));
+            SetPlayerTechResearched(whichFaction.Player, ResearchId, 1);
+            if (whichFaction.Player != null)
+                HighBourneArea.Rect.ChangeUnitsOwningPlayer(Player(GetPlayerNeutralPassive()), whichFaction.Player);
+        }
+
+        protected override void OnAdd(Faction whichFaction)
+        {
+            base.OnAdd(whichFaction);
+            whichFaction.ModObjectLimit(ResearchId, Faction.UNLIMITED);
+        }
+
+        protected override void OnFail(Faction whichFaction)
+        {
+            base.OnFail(whichFaction);
+            whichFaction.ModObjectLimit(ResearchId, -Faction.UNLIMITED);
+        }
+
+        
+    }
+}

--- a/src/WarcraftLegacies.Source/Quests/Warsong/QuestScepterOfTheQueenWarsong.cs
+++ b/src/WarcraftLegacies.Source/Quests/Warsong/QuestScepterOfTheQueenWarsong.cs
@@ -2,6 +2,7 @@
 using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
+using System.Collections.Generic;
 using WarcraftLegacies.Source.Setup;
 using WarcraftLegacies.Source.Setup.Legends;
 using WCSharp.Shared.Data;
@@ -9,27 +10,31 @@ using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Warsong
 {
-    public class QuestScepterOfTheQueenWarsong : QuestData
+    public sealed class QuestScepterOfTheQueenWarsong : QuestData
     {
         public QuestScepterOfTheQueenWarsong(Rectangle area) : base("Royal Plunder", "Remnants of the ancient Highborne survive within the ruins of Dire Maul. If Feathermoon Stronghold falls, it would become a simple matter to slaughter the Highborne and plunder their artifacts.", "ReplaceableTextures\\CommandButtons\\BTNNagaWeaponUp2.blp")
         {
-            HighBourneArea = area;
+            _highBourneArea = area;
             AddObjective(new ObjectiveLegendNotPermanentlyDead(LegendWarsong.StonemaulKeep));
             AddObjective(new ObjectiveLegendDead(LegendSentinels.legendFeathermoon));
-            AddObjective(new ObjectiveAnyUnitInRect(HighBourneArea, "Dire Maul", true));
-            HighBourneArea.Rect.MakeUnitsInvulnerable();
+            AddObjective(new ObjectiveAnyUnitInRect(_highBourneArea, "Dire Maul", true));
+           _highBourneAreaUnits = _highBourneArea.Rect.MakeUnitsInvulnerable(Player(GetPlayerNeutralPassive()));
         }
 
-        private Rectangle HighBourneArea { get; }
+        private List<unit> _highBourneAreaUnits;
+        private Rectangle _highBourneArea { get; }
+   
+        /// <inheritdoc/>
         protected override string CompletionPopup => "The Highborne are no longer implicitly defended by the Night Elven presence at Feathermoon Stronghold. The Horde unleashes their full might against these Night Elven arcanists.";
+        /// <inheritdoc/>
         protected override string RewardDescription => "Gain the Scepter of the Queen and turn all units in Dire Maul hostile";
 
+        /// <inheritdoc/>
         protected override void OnComplete(Faction whichFaction)
         {
-            base.OnComplete(whichFaction);
-            ArtifactSetup.ArtifactScepterofthequeen?.Item.SetPosition(new Point(GetRectCenterX(HighBourneArea.Rect), GetRectCenterY(HighBourneArea.Rect)));
+            ArtifactSetup.ArtifactScepterofthequeen?.Item.SetPosition(new Point(GetRectCenterX(_highBourneArea.Rect), GetRectCenterY(_highBourneArea.Rect)));
             if (whichFaction.Player != null)
-                HighBourneArea.Rect.ChangeUnitsOwningPlayer(Player(GetPlayerNeutralPassive()), whichFaction.Player);
+                Player(GetPlayerNeutralAggressive()).MakeUnitsOwner(_highBourneAreaUnits);
         }
     }
 }

--- a/src/WarcraftLegacies.Source/Quests/Warsong/QuestScepterOfTheQueenWarsong.cs
+++ b/src/WarcraftLegacies.Source/Quests/Warsong/QuestScepterOfTheQueenWarsong.cs
@@ -1,0 +1,35 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using MacroTools.QuestSystem;
+using MacroTools.QuestSystem.UtilityStructs;
+using WarcraftLegacies.Source.Setup;
+using WarcraftLegacies.Source.Setup.Legends;
+using WCSharp.Shared.Data;
+using static War3Api.Common;
+
+namespace WarcraftLegacies.Source.Quests.Warsong
+{
+    public class QuestScepterOfTheQueenWarsong : QuestData
+    {
+        public QuestScepterOfTheQueenWarsong(Rectangle area) : base("Royal Plunder", "Remnants of the ancient Highborne survive within the ruins of Dire Maul. If Feathermoon Stronghold falls, it would become a simple matter to slaughter the Highborne and plunder their artifacts.", "ReplaceableTextures\\CommandButtons\\BTNNagaWeaponUp2.blp")
+        {
+            HighBourneArea = area;
+            AddObjective(new ObjectiveLegendNotPermanentlyDead(LegendWarsong.StonemaulKeep));
+            AddObjective(new ObjectiveLegendDead(LegendSentinels.legendFeathermoon));
+            AddObjective(new ObjectiveAnyUnitInRect(HighBourneArea, "Dire Maul", true));
+            HighBourneArea.Rect.MakeUnitsInvulnerable();
+        }
+
+        private Rectangle HighBourneArea { get; }
+        protected override string CompletionPopup => "The Highborne are no longer implicitly defended by the Night Elven presence at Feathermoon Stronghold. The Horde unleashes their full might against these Night Elven arcanists.";
+        protected override string RewardDescription => "Gain the Scepter of the Queen and turn all units in Dire Maul hostile";
+
+        protected override void OnComplete(Faction whichFaction)
+        {
+            base.OnComplete(whichFaction);
+            ArtifactSetup.ArtifactScepterofthequeen?.Item.SetPosition(new Point(GetRectCenterX(HighBourneArea.Rect), GetRectCenterY(HighBourneArea.Rect)));
+            if (whichFaction.Player != null)
+                HighBourneArea.Rect.ChangeUnitsOwningPlayer(Player(GetPlayerNeutralPassive()), whichFaction.Player);
+        }
+    }
+}

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/SentinelsQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/SentinelsQuestSetup.cs
@@ -20,7 +20,7 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
       sentinels.AddQuest(new QuestSentinelsKillWarsong());
       sentinels.AddQuest(new QuestSentinelsKillFrostwolf());
       sentinels.AddQuest(new QuestMaievOutland(Regions.MaievStartUnlock));
-      //sentinels.AddQuest(new QuestScepterOfTheQueenSentinels());
+      sentinels.AddQuest(new QuestScepterOfTheQueenSentinels(Regions.HighBourne));
       sentinels.AddQuest(new QuestVaultoftheWardens());
     }
   }

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/WarsongQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/WarsongQuestSetup.cs
@@ -18,6 +18,7 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
       warsong.AddQuest(new QuestMoreWyverns());
       warsong.AddQuest(new QuestWarsongHold());
       warsong.AddQuest(new QuestJergosh());
+      warsong.AddQuest(new QuestScepterOfTheQueenWarsong(Regions.HighBourne));
     }
   }
 }


### PR DESCRIPTION
As already discussed in the comments of #62 I had no way of testing whether the units changing owner upon completion of the quest is actually working.

I made a rectExtension class to prevent duplication of code used in both Scepter Quests. 
I feel like extension methods do not really fit here but I couldn't find any other helper classes that are used in the same way so I figured I stick to the pattern that's already there.