### PR TITLE
#87 Kul'Tiras quests

### DIFF
--- a/src/WarcraftLegacies.Source/Quests/KulTiras/QuestBeyondPortal.cs
+++ b/src/WarcraftLegacies.Source/Quests/KulTiras/QuestBeyondPortal.cs
@@ -1,12 +1,17 @@
-using MacroTools.QuestSystem;
+﻿using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
 using WarcraftLegacies.Source.Setup.Legends;
-using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.KulTiras
 {
+  /// <summary>
+  /// Varuious Fel Horde buildings must be destroyed or controlled to unlock Fusillier. 
+  /// </summary>
   public sealed class QuestBeyondPortal : QuestData
   {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestBeyondPortal"/> class.
+    /// </summary>
     public QuestBeyondPortal() : base("Beyond the Dark Portal",
       "The Orc threat from Draenor still looms over all. Eliminate every trace of the Orcs and their bases.",
       "ReplaceableTextures\\CommandButtons\\BTNDarkPortal.blp")
@@ -15,11 +20,13 @@ namespace WarcraftLegacies.Source.Quests.KulTiras
       AddObjective(new ObjectiveLegendDead(LegendFelHorde.LegendHellfirecitadel));
       AddObjective(new ObjectiveLegendDead(LegendFelHorde.LegendBlackrockspire));
       AddObjective(new ObjectiveSelfExists());
-      ResearchId = FourCC("R085");
+      ResearchId = Constants.UPGRADE_R085_QUEST_COMPLETED_BEYOND_THE_DARK_PORTAL;
     }
-    
+
+    /// <inheritdoc/>
     protected override string CompletionPopup => "The orcs are no more and we can now train Fusillier.";
 
+    /// <inheritdoc/>
     protected override string RewardDescription => "You will be able to train Fusillier from the Barrack";
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/KulTiras/QuestJoinCrusade.cs
+++ b/src/WarcraftLegacies.Source/Quests/KulTiras/QuestJoinCrusade.cs
@@ -1,4 +1,4 @@
-using MacroTools.FactionSystem;
+﻿using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
 using WarcraftLegacies.Source.Setup;
@@ -7,26 +7,32 @@ using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.KulTiras
 {
+  /// <summary>
+  /// The player join the Scarlet Crusade.
+  /// </summary>
   public sealed class QuestJoinCrusade : QuestData
   {
-    private static readonly int QuestResearchId = FourCC("R06U"); //This research is given when the quest is completed
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestJoinCrusade"/> class.
+    /// </summary>
     public QuestJoinCrusade() : base("Join the Crusade",
       "Daelin Proudmoore sees the plight of the Scarlet Crusade. As fellow human survivors of horrible war, they should join forces with Kul'tiras",
       "ReplaceableTextures\\CommandButtons\\BTNDivine_Reckoning_Icon.blp")
     {
-      AddObjective(new ObjectiveCastSpell(FourCC("A0JB"), true));
-      ResearchId = QuestResearchId;
+      AddObjective(new ObjectiveCastSpell(Constants.ABILITY_A0JB_JOIN_THE_CRUSADE_KULTIRASPATH, true));
+      ResearchId = Constants.UPGRADE_R06U_QUEST_COMPLETED_JOIN_THE_CRUSADE;
     }
 
+    /// <inheritdoc/>
+    protected override string CompletionPopup => "Kul'tiras has joined the Scarlet Crusade";
 
-    protected override string CompletionPopup => "Kul Tiras has joined the Scarlet Crusade";
-
+    /// <inheritdoc/>
     protected override string RewardDescription => "Unlock Order Inquisitor and join the Scarlet Crusade";
 
+    /// <inheritdoc/>
     protected override void OnComplete(Faction completingFaction)
     {
-      UnitRemoveAbility(LegendKultiras.LegendAdmiral.Unit, FourCC("A0JB"));
+      UnitRemoveAbility(LegendKultiras.LegendAdmiral.Unit, Constants.ABILITY_A0JB_JOIN_THE_CRUSADE_KULTIRASPATH);
       completingFaction.Player?.SetTeam(TeamSetup.ScarletCrusade);
     }
   }

--- a/src/WarcraftLegacies.Source/Quests/KulTiras/QuestSafeSea.cs
+++ b/src/WarcraftLegacies.Source/Quests/KulTiras/QuestSafeSea.cs
@@ -1,28 +1,35 @@
-using MacroTools.ControlPointSystem;
+﻿using MacroTools.ControlPointSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
-using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.KulTiras
 {
+  /// <summary>
+  /// Various control points must be captured.
+  /// </summary>
   public sealed class QuestSafeSea : QuestData
   {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestSafeSea"/> class.
+    /// </summary>
     public QuestSafeSea() : base("Safe Sea Decree",
       "The seas must be secured and the Kul'tiras navy must be returned to its former glory!", @"ReplaceableTextures\
           \CommandButtons\\BTNKulTirasDreadnought.blp")
     {
-      AddObjective(new ObjectiveTrain(FourCC("hdes"), FourCC("hshy"), 2));
-      AddObjective(new ObjectiveTrain(FourCC("h04J"), FourCC("hshy"), 1));
-      AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(FourCC("n01W"))));
-      AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(FourCC("n07L"))));
-      AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(FourCC("n08Q"))));
-      AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(FourCC("n09K"))));
-      ResearchId = FourCC("R06T");
+      AddObjective(new ObjectiveTrain(Constants.UNIT_HDES_DESTROYER_ALLIANCE, Constants.UNIT_HSHY_ALLIANCE_SHIPYARD_LORDAERON, 2));
+      AddObjective(new ObjectiveTrain(Constants.UNIT_H04J_WARSHIP_KUL_TIRAS, Constants.UNIT_HSHY_ALLIANCE_SHIPYARD_LORDAERON, 1));
+      AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(Constants.UNIT_N01W_BORALUS_25GOLD_MIN)));
+      AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(Constants.UNIT_N07L_BALOR_15GOLD_MIN)));
+      AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(Constants.UNIT_N08Q_TOL_BARAD_20GOLD_MIN)));
+      AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(Constants.UNIT_N09K_CRESTFALL_10GOLD_MIN)));
+      ResearchId = Constants.UPGRADE_R06T_QUEST_COMPLETED_SAFE_SEA_DECREE;
     }
 
+    /// <inheritdoc/>
     protected override string CompletionPopup =>
       "With the seas now secure, the Ember Order can be reformed and Lucille Waycrest is trainable";
 
+    /// <inheritdoc/>
     protected override string RewardDescription => "The Order of Embers is reborn and Lucille Waycrest is trainable";
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/KulTiras/QuestUnlockShip.cs
+++ b/src/WarcraftLegacies.Source/Quests/KulTiras/QuestUnlockShip.cs
@@ -1,20 +1,30 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
-using MacroTools.Wrappers;
 using WarcraftLegacies.Source.Setup.Legends;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
+using static War3Api.Blizzard;
+using WarcraftLegacies.Source.Setup.FactionSetup;
+using WarcraftLegacies.Source.Setup;
 
 namespace WarcraftLegacies.Source.Quests.KulTiras
 {
+  /// <summary>
+  /// Proudmoore captial ship starts locked. Boralus and Dazar'Alor must be captured to unlock it.
+  /// </summary>
   public sealed class QuestUnlockShip : QuestData
   {
     private readonly unit _proudmooreCapitalShip;
     private readonly List<unit> _rescueUnits = new();
-
+    private readonly Rectangle _rescueRect;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestUnlockShip"/> class.
+    /// </summary>
+    /// <param name="rescueRect">All units in this area will be made neutral, then rescued when the quest is completed.</param>
+    /// <param name="proudmooreCapitalShip">starts invulnerable and unusable. Made usuable and vulnerable when the quest is completed.</param>
     public QuestUnlockShip(Rectangle rescueRect, unit proudmooreCapitalShip) : base("The Zandalar Menace",
       "The Troll Empire of Zandalar is a danger to the safety of Kul'tiras and the Alliance. Before setting sail, we must eliminate them.",
       "ReplaceableTextures\\CommandButtons\\BTNGalleonIcon.blp")
@@ -22,45 +32,67 @@ namespace WarcraftLegacies.Source.Quests.KulTiras
       AddObjective(new ObjectiveControlLegend(LegendNeutral.LegendDazaralor, false));
       AddObjective(new ObjectiveControlLegend(LegendKultiras.LegendBoralus, true));
       _proudmooreCapitalShip = proudmooreCapitalShip;
-
-      foreach (var unit in new GroupWrapper().EnumUnitsInRect(rescueRect).EmptyToList())
-        if (GetOwningPlayer(unit) == Player(PLAYER_NEUTRAL_PASSIVE))
-        {
-          SetUnitInvulnerable(unit, true);
-          _rescueUnits.Add(unit);
-        }
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(Player(PLAYER_NEUTRAL_PASSIVE));
+      _rescueRect = rescueRect;
     }
 
+    /// <inheritdoc/>
     protected override string FailurePopup =>
-      "Boralus has fallen, Katherine has escaped on the Proudmoore Capital Ship with a handful of Survivors.";
+      "Boralus has fallen, but Katherine and Daelin have escaped on the Proudmoore Capital Ship with a handful of Survivors.";
 
+    /// <inheritdoc/>
     protected override string PenaltyDescription =>
-      "You lose everything you control, but you gain Katherine at the capital ship.";
+      "You lose everything you control, but you gain Katherine and Daelin Proudmoore at the Proudmoore Capital Ship.";
 
-    protected override string CompletionPopup => "The Proudmoore capital ship is now ready to sails!";
+    /// <inheritdoc/>
+    protected override string CompletionPopup => "The Proudmoore Capital Ship is now ready to set sail!";
 
+    /// <inheritdoc/>
     protected override string RewardDescription =>
       "Unpause the Proudmoore capital ship and unlocks the buildings inside.";
 
+    /// <inheritdoc/>
     protected override void OnComplete(Faction completingFaction)
     {
-      foreach (var unit in _rescueUnits) unit.Rescue(completingFaction.Player);
-      PauseUnit(_proudmooreCapitalShip, false);
+      if (completingFaction.Player != null)
+      {
+        completingFaction.Player.RescueGroup(_rescueUnits);
+        _proudmooreCapitalShip.Rescue(completingFaction.Player);
+      }
+      else
+      {
+        Player(bj_PLAYER_NEUTRAL_VICTIM).RescueGroup(_rescueUnits);
+        _proudmooreCapitalShip.Rescue(Player(PLAYER_NEUTRAL_AGGRESSIVE));
+      }
+      PauseUnitBJ(false, _proudmooreCapitalShip);
+      KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
+      ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
     }
 
+    /// <inheritdoc/>
     protected override void OnFail(Faction completingFaction)
     {
       LegendKultiras.LegendKatherine.StartingXp = GetHeroXP(LegendKultiras.LegendKatherine.Unit);
       completingFaction.Obliterate();
-      LegendKultiras.LegendKatherine.ForceCreate(completingFaction.Player, new Point(-15223, -22856), 110);
-      UnitAddItem(LegendKultiras.LegendKatherine.Unit,
-        CreateItem(FourCC("I00M"), GetUnitX(LegendKultiras.LegendKatherine.Unit),
-          GetUnitY(LegendKultiras.LegendKatherine.Unit)));
-      if (GetLocalPlayer() == completingFaction.Player)
-        SetCameraPosition(Regions.ShipAmbient.Center.X, Regions.ShipAmbient.Center.Y);
-      foreach (var unit in _rescueUnits) unit.Rescue(completingFaction.Player);
-      PauseUnit(_proudmooreCapitalShip, true);
-      SetUnitOwner(_proudmooreCapitalShip, completingFaction.Player, true);
+      if (completingFaction.Player != null)
+      {
+        LegendKultiras.LegendKatherine.ForceCreate(completingFaction.Player, new Point(_rescueRect.Center.X, _rescueRect.Center.Y), 110);
+        LegendKultiras.LegendAdmiral.ForceCreate(completingFaction.Player, new Point(_rescueRect.Center.X, _rescueRect.Center.Y), 110);
+        if (GetLocalPlayer() == completingFaction.Player)
+          SetCameraPosition(_rescueRect.Center.X, _rescueRect.Center.Y);
+        completingFaction.Player.RescueGroup(_rescueUnits);
+        completingFaction.Player.AddGold(500);
+        completingFaction.Player.AddLumber(2000);
+        _proudmooreCapitalShip.Rescue(completingFaction.Player);
+      }
+      else
+      {
+        _proudmooreCapitalShip.Rescue(Player(PLAYER_NEUTRAL_AGGRESSIVE));
+      }
+      PauseUnitBJ(false, _proudmooreCapitalShip);
+      IssuePointOrderLocBJ(_proudmooreCapitalShip, "move", GetRectCenter(Regions.SouthshoreUnlock.Rect));
+      KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
+      ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/KulTiras/QuestUnlockShip.cs
+++ b/src/WarcraftLegacies.Source/Quests/KulTiras/QuestUnlockShip.cs
@@ -64,7 +64,7 @@ namespace WarcraftLegacies.Source.Quests.KulTiras
         Player(bj_PLAYER_NEUTRAL_VICTIM).RescueGroup(_rescueUnits);
         _proudmooreCapitalShip.Rescue(Player(PLAYER_NEUTRAL_AGGRESSIVE));
       }
-      PauseUnitBJ(false, _proudmooreCapitalShip);
+      _proudmooreCapitalShip.Pause(false);
       KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
       ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
     }
@@ -89,8 +89,8 @@ namespace WarcraftLegacies.Source.Quests.KulTiras
       {
         _proudmooreCapitalShip.Rescue(Player(PLAYER_NEUTRAL_AGGRESSIVE));
       }
-      PauseUnitBJ(false, _proudmooreCapitalShip);
-      IssuePointOrderLocBJ(_proudmooreCapitalShip, "move", GetRectCenter(Regions.SouthshoreUnlock.Rect));
+      _proudmooreCapitalShip.Pause(false); 
+      IssuePointOrder(_proudmooreCapitalShip, "move", Regions.SouthshoreUnlock.Center.X, Regions.SouthshoreUnlock.Center.Y);
       KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
       ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
     }


### PR DESCRIPTION
This bit in `QuestTheramore` could be simplified if all theramore units would start as neutral passive by default. 
Definetly should be kept in mind because this will stop working if someone decides to 'fix' that in the map itself.
`   if (KultirasSetup.Kultiras?.Player != null)
      _rescueUnits = theramoreRect.PrepareUnitsForRescue(KultirasSetup.Kultiras.Player); 
      Player(PLAYER_NEUTRAL_PASSIVE).RescueGroup(_rescueUnits); // Have to make units neutral because they are owned by Kul'Tiras by default`

Also english is not my first language so I apologize for any spelling and grammar mistakes I made in the flavour texts and comments