### PR TITLE
Victory Imminent Message Spam Fix

### DIFF
--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -568,7 +568,7 @@ namespace MacroTools.FactionSystem
         {
           SetUnitOwner(unit,
             Player?.GetTeam()?.Size > 1
-              ? playersToDistributeTo[GetRandomInt(0, playersToDistributeTo.Count)]
+              ? playersToDistributeTo[GetRandomInt(0, playersToDistributeTo.Count-1)]
               : Player(GetBJPlayerNeutralVictim()), false);
         }
       }

--- a/src/WarcraftLegacies.Source/GameLogic/GameEnd/ControlPointVictory.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/GameEnd/ControlPointVictory.cs
@@ -47,12 +47,13 @@ namespace WarcraftLegacies.Source.GameLogic.GameEnd
       ControlPointOwnerChangeEventArgs controlPointOwnerChangeEventArgs)
     {
       if (VictoryDefeat.GameWon) return;
-      var team = controlPointOwnerChangeEventArgs.ControlPoint.Owner.GetTeam();
-      if (team == null) return;
-      var teamControlPoints = GetTeamControlPoints(team);
+      var newOwnerTeam = controlPointOwnerChangeEventArgs.ControlPoint.Owner.GetTeam();
+      var formerOwnerTeam = controlPointOwnerChangeEventArgs.FormerOwner.GetTeam();
+      if (newOwnerTeam == null || newOwnerTeam == formerOwnerTeam) return;
+      var teamControlPoints = GetTeamControlPoints(newOwnerTeam);
       if (teamControlPoints >= _cpsVictory)
-        VictoryDefeat.TeamVictory(team);
-      else if (teamControlPoints > CpsWarning) TeamWarning(team, teamControlPoints);
+        VictoryDefeat.TeamVictory(newOwnerTeam);
+      else if (teamControlPoints > CpsWarning) TeamWarning(newOwnerTeam, teamControlPoints);
     }
 
     public static void Setup()


### PR DESCRIPTION
Get the former owner team of the changing control point and check if the new team is different from the former before doing victory checking.

This should sort the issue where messages get spammed on the screen when a player leaves the game whose team have over the CPS_WARNING number of control points.

Fixed an index out of bounds exception when trying to distribute units to other players in the faction