### PR TITLE
Book related issues #179  #281

### DIFF
--- a/src/MacroTools/ArtifactSystem/ArtifactManager.cs
+++ b/src/MacroTools/ArtifactSystem/ArtifactManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using MacroTools.Extensions;
 using MacroTools.ShoreSystem;
 using WCSharp.Events;
@@ -62,7 +63,7 @@ namespace MacroTools.ArtifactSystem
     /// Returns all <see cref="Artifact"/>s registered to the system.
     /// </summary>
     public static IEnumerable<Artifact> GetAllArtifacts() =>
-      AllArtifacts.AsReadOnly();
+      AllArtifacts.AsReadOnly().OrderBy(a => GetItemName(a.Item));
 
     /// <summary>
     /// Completely removes the given Artifact from the game.

--- a/src/MacroTools/BookSystem/ArtifactSystem/ArtifactBook.cs
+++ b/src/MacroTools/BookSystem/ArtifactSystem/ArtifactBook.cs
@@ -17,13 +17,10 @@ namespace MacroTools.BookSystem.ArtifactSystem
     /// <summary>
     /// Initializes a new instance of the <see cref="ArtifactBook"/> class.
     /// </summary>
-    public ArtifactBook() : base(0.65f, 0.37f, 0.015f, 0.02f)
+    public ArtifactBook() : base(0.65f, 0.37f, 0.015f, 0.02f, "Artifacts", new Point(0.4f, 0.38f), BlzGetFrameByName("UpperButtonBarQuestsButton", 0), true)
     {
       ArtifactManager.ArtifactRegistered += ArtifactCreated;
       AddPagesAndArtifacts();
-      Title = "Artifacts";
-      LauncherParent = BlzGetFrameByName("UpperButtonBarQuestsButton", 0);
-      Position = new Point(0.4f, 0.38f);
     }
 
     private void AddArtifact(Artifact artifact)
@@ -49,7 +46,7 @@ namespace MacroTools.BookSystem.ArtifactSystem
     {
       foreach (var page in Pages)
       {
-        page.Visible = false; //This avoid a crash to desktop when rerendering a Book that a player has open.
+        page.Visible = false; //This avoids a crash to desktop when rerendering a Book that a player has open.
         page.Dispose();
       }
 

--- a/src/MacroTools/BookSystem/BookManager.cs
+++ b/src/MacroTools/BookSystem/BookManager.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using MacroTools.Extensions;
-using MacroTools.Frames;
 using static War3Api.Common;
 
 namespace MacroTools.BookSystem
@@ -18,32 +16,9 @@ namespace MacroTools.BookSystem
     /// Registers a <see cref="IBook"/> as being visible to all players.
     /// </summary>
     /// <param name="book">The book to register.</param>
-    /// <param name="whichPlayer">If specified, the Book can only be seen by this player.</param>
-    public static void Register(IBook book, player? whichPlayer = null)
+    public static void Register(IBook book)
     {
       Books.Add(book);
-      var launcherButton = new Button("ScriptDialogButton", BlzGetOriginFrame(ORIGIN_FRAME_GAME_UI, 0), 0)
-      {
-        Width = book.LauncherParent.GetWidth(),
-        Height = book.LauncherParent.GetHeight(),
-        Text = book.Title,
-        Visible = whichPlayer == null || whichPlayer == GetLocalPlayer()
-      };
-      launcherButton.SetPoint(FRAMEPOINT_TOP, book.LauncherParent, FRAMEPOINT_BOTTOM, 0, 0);
-      launcherButton.OnClick = triggerPlayer =>
-      {
-        if (triggerPlayer != GetLocalPlayer()) 
-          return;
-        book.Visible = true;
-        launcherButton.Visible = false;
-      };
-      book.OnClickExitButton = triggerPlayer =>
-      {
-        if (triggerPlayer != GetLocalPlayer()) 
-          return;
-        book.Visible = false;
-        launcherButton.Visible = true;
-      };
     }
 
     private static void LoadToc(string tocFilePath)

--- a/src/MacroTools/BookSystem/IBook.cs
+++ b/src/MacroTools/BookSystem/IBook.cs
@@ -15,15 +15,6 @@ namespace MacroTools.BookSystem
     /// Determines whether or not the book is visible.
     /// </summary>
     public bool Visible { get; set; }
-    
-    /// <summary>
-    /// Fired when the exit button is clicked.
-    /// </summary>
-    public OnClickAction OnClickExitButton { set; }
-    
-    /// <summary>
-    ///    The name of the Book's launcher Button.
-    /// </summary>
-    public string Title { get; init; }
+        
   }
 }

--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using MacroTools.Augments;
 using MacroTools.Extensions;
 using MacroTools.QuestSystem;
@@ -518,7 +519,8 @@ namespace MacroTools.FactionSystem
     /// </summary>
     public IEnumerable<Power> GetAllPowers()
     {
-      foreach (var power in _powers) yield return power;
+      foreach (var power in _powers.OrderBy(p => p.Name)) 
+        yield return power;
     }
 
     private void DistributeExperience(IEnumerable<player> playersToDistributeTo)

--- a/src/TestMap.Source/Setup/BookSetup.cs
+++ b/src/TestMap.Source/Setup/BookSetup.cs
@@ -16,7 +16,7 @@ namespace TestMap.Source.Setup
     public static void Setup()
     {
       foreach (var player in WCSharp.Shared.Util.EnumeratePlayers()) 
-        BookManager.Register(new PowerBook(player), player);
+        BookManager.Register(new PowerBook(player));
       BookManager.Register(new ArtifactBook());
     }
   }

--- a/src/WarcraftLegacies.Source/Setup/BookSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/BookSetup.cs
@@ -15,7 +15,7 @@ namespace WarcraftLegacies.Source.Setup
     public static void Setup()
     {
       foreach (var player in WCSharp.Shared.Util.EnumeratePlayers()) 
-        BookManager.Register(new PowerBook(player), player);
+          BookManager.Register(new PowerBook(player));
       BookManager.Register(new ArtifactBook());
     }
   }


### PR DESCRIPTION
Implemented the same logic to re-render the contents of the `PowerBook` as for the `ArtiFactBook`.
Also added `OrderBy` extension methos to the Get methods of powers and artifacts.

I looked at your commit for #372 and a bug we've already fixed in #135 came back with that commit. 
Basically when an item gets removed so that the page is now empty, even after reshuffling the book it shows the wrong page because `_activePageIndex` does not get reset.
So I fixed that.

I realise that with the way I fixed this I kinda reverted what you did in #372 and I am not too happy with the way this turned out but I couldn't think of a better solution so yea.




