### PR TITLE
Stonemaul fix

### DIFF
--- a/src/MacroTools/QuestSystem/UtilityStructs/ObjectiveUnitIsDead.cs
+++ b/src/MacroTools/QuestSystem/UtilityStructs/ObjectiveUnitIsDead.cs
@@ -6,13 +6,13 @@ using static War3Api.Common;
 
 namespace MacroTools.QuestSystem.UtilityStructs
 {
-  public class ObjectiveUnitIsDead : Objective
+  public sealed class ObjectiveUnitIsDead : Objective
   {
     public ObjectiveUnitIsDead(unit unitToKill)
     {
-      trigger trig = CreateTrigger();
-      TriggerRegisterUnitEvent(trig, unitToKill, EVENT_UNIT_DEATH);
-      TriggerAddAction(trig, OnUnitDeath);
+      CreateTrigger()
+        .RegisterUnitEvent(unitToKill, EVENT_UNIT_DEATH)
+        .AddAction(() => { Progress = QuestProgress.Complete; });
       Target = unitToKill;
       TargetWidget = Target;
       InitializeDescription();
@@ -23,12 +23,7 @@ namespace MacroTools.QuestSystem.UtilityStructs
     public override Point Position => new(GetUnitX(Target), GetUnitY(Target));
 
     public unit Target { get; }
-
-    private void OnUnitDeath()
-    {
-      Progress = QuestProgress.Complete;
-    }
-
+    
     private void InitializeDescription()
     {
       if (IsUnitType(Target, UNIT_TYPE_STRUCTURE) || IsUnitType(Target, UNIT_TYPE_ANCIENT))

--- a/src/MacroTools/QuestSystem/UtilityStructs/ObjectiveUnitIsDead.cs
+++ b/src/MacroTools/QuestSystem/UtilityStructs/ObjectiveUnitIsDead.cs
@@ -1,0 +1,43 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using WCSharp.Events;
+using WCSharp.Shared.Data;
+using static War3Api.Common;
+
+namespace MacroTools.QuestSystem.UtilityStructs
+{
+  public class ObjectiveUnitIsDead : Objective
+  {
+    public ObjectiveUnitIsDead(unit unitToKill)
+    {
+      trigger trig = CreateTrigger();
+      TriggerRegisterUnitEvent(trig, unitToKill, EVENT_UNIT_DEATH);
+      TriggerAddAction(trig, OnUnitDeath);
+      Target = unitToKill;
+      TargetWidget = Target;
+      InitializeDescription();
+      DisplaysPosition = IsUnitType(Target, UNIT_TYPE_STRUCTURE) ||
+                         GetOwningPlayer(Target) == Player(PLAYER_NEUTRAL_AGGRESSIVE);
+    }
+
+    public override Point Position => new(GetUnitX(Target), GetUnitY(Target));
+
+    public unit Target { get; }
+
+    private void OnUnitDeath()
+    {
+      Progress = QuestProgress.Complete;
+    }
+
+    private void InitializeDescription()
+    {
+      if (IsUnitType(Target, UNIT_TYPE_STRUCTURE) || IsUnitType(Target, UNIT_TYPE_ANCIENT))
+      {
+        Description = GetUnitName(Target) + "has been destroyed.";
+        return;
+      }
+
+      Description = GetUnitName(Target) + "is dead.";
+    }
+  }
+}

--- a/src/WarcraftLegacies.Source/Quests/Dragonmaw/QuestStonemaul.cs
+++ b/src/WarcraftLegacies.Source/Quests/Dragonmaw/QuestStonemaul.cs
@@ -21,7 +21,7 @@ namespace WarcraftLegacies.Source.Quests.Dragonmaw
       "ReplaceableTextures\\CommandButtons\\BTNMercenaryCamp.blp")
     {
       AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(Constants.UNIT_N022_STONEMAUL_20GOLD_MIN)));
-      AddObjective(new ObjectiveKillUnit(preplacedUnitSystem.GetUnit(Constants.UNIT_NOGA_STONEMAUL_WARCHIEF_KOR_GALL)));
+      AddObjective(new ObjectiveUnitIsDead(preplacedUnitSystem.GetUnit(Constants.UNIT_NOGA_STONEMAUL_WARCHIEF_KOR_GALL)));
       AddObjective(new ObjectiveLegendInRect(LegendDragonmaw.Zaela, Regions.StonemaulKeep, "Stonemaul"));
       AddObjective(new ObjectiveExpire(1327));
       AddObjective(new ObjectiveSelfExists());

--- a/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestRexxar.cs
+++ b/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestRexxar.cs
@@ -25,7 +25,7 @@ namespace WarcraftLegacies.Source.Quests.Frostwolf
       "Rexxar is having trouble with a beligerent Ogre Warlord, slay the Chieftain to gain the heroe's allegiance.",
       "ReplaceableTextures\\CommandButtons\\BTNOneHeadedOgre.blp")
     {
-      AddObjective(new ObjectiveKillUnit(preplacedUnitSystem.GetUnit(Constants.UNIT_NOGA_STONEMAUL_WARCHIEF_KOR_GALL)));
+      AddObjective(new ObjectiveUnitIsDead(preplacedUnitSystem.GetUnit(Constants.UNIT_NOGA_STONEMAUL_WARCHIEF_KOR_GALL)));
       AddObjective(new ObjectiveSelfExists());
       ResearchId = Constants.UPGRADE_R03S_QUEST_COMPLETED_THE_CHIEFTAIN_S_CHALLENGE_FROSTWOLF;
 


### PR DESCRIPTION
Added ObjectiveUnitIsDead
Updated the kill Kor'Gall quests to use new ObjectiveUnitIsDead

Closes #481 

An alternate way to do this would have been to make Kor'Gall a legend and use ObjectiveLegendDead