### PR TITLE
issued #456 #457 #461

### DIFF
--- a/src/MacroTools/Extensions/RectangleExtensions.cs
+++ b/src/MacroTools/Extensions/RectangleExtensions.cs
@@ -29,33 +29,32 @@ namespace MacroTools.Extensions
     /// </summary>
     /// <param name="rectangle">The rectangle in which to prepare units.</param>
     /// <param name="rescuePreparationMode">Determines how units are prepared.</param>
-    /// <param name="owningPlayer">The player owning the units inside <paramref name="rectangle"/></param>
     /// <param name="filter">A function that is applied to each unit found in <paramref name="rectangle"/>
     /// <para/>
     /// The unit gets rescued if <paramref name="filter"/> returns true, else it does not get rescued.
     /// </param>
     /// <returns>Returns all <paramref name="owningPlayer"/> units in the specified rectangle. Default is neutral passive.</returns>
-    public static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, RescuePreparationMode rescuePreparationMode, player? owningPlayer = null, Func<unit, bool>? filter = null)
+    public static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, RescuePreparationMode rescuePreparationMode, Func<unit, bool>? filter = null)
     {
-      owningPlayer ??= Player(PLAYER_NEUTRAL_PASSIVE);
+     
       filter ??= unit => { return true; }; 
       switch (rescuePreparationMode)
       {
         case RescuePreparationMode.None:
         {
-          return PrepareUnitsForRescue(rectangle, false, false, false, owningPlayer, filter);
+          return PrepareUnitsForRescue(rectangle, false, false, false, filter);
         }
         case RescuePreparationMode.Invulnerable:
         {
-          return PrepareUnitsForRescue(rectangle,true, false, false, owningPlayer, filter);
+          return PrepareUnitsForRescue(rectangle,true, false, false,  filter);
         }
         case RescuePreparationMode.HideNonStructures:
         {
-          return PrepareUnitsForRescue(rectangle,true,true, false, owningPlayer, filter);
+          return PrepareUnitsForRescue(rectangle,true,true, false,  filter);
         }
         case RescuePreparationMode.HideAll:
         {
-          return PrepareUnitsForRescue(rectangle, true, true, true, owningPlayer, filter);
+          return PrepareUnitsForRescue(rectangle, true, true, true,  filter);
         }
         default:
           throw new ArgumentException($"{nameof(rescuePreparationMode)} is not implemented for this function.", nameof(rescuePreparationMode));
@@ -69,15 +68,14 @@ namespace MacroTools.Extensions
     /// <param name="makeInvulnerable">If true, prepared units are made invulnerable.</param>
     /// <param name="hideUnits">If true, prepared units are hidden.</param>
     /// <param name="hideStructures">If true, prepared structures are hidden.</param>
-    /// <param name="owningPlayer">The player owning the units inside <paramref name="rectangle"/></param>
     /// <param name="filter"></param>
     /// <returns>All Neutral Passive units in the specified rectangle.</returns>
-    private static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, bool makeInvulnerable, bool hideUnits, bool hideStructures, player owningPlayer, Func<unit, bool> filter)
+    private static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, bool makeInvulnerable, bool hideUnits, bool hideStructures, Func<unit, bool> filter)
     {
       var group = new GroupWrapper()
         .EnumUnitsInRect(rectangle)
         .EmptyToList()
-        .Where(x => x.OwningPlayer() == owningPlayer && filter.Invoke(x))
+        .Where(x => x.OwningPlayer() == Player(PLAYER_NEUTRAL_PASSIVE) && filter.Invoke(x))
         .ToList();
       foreach (var unit in group)
       {

--- a/src/MacroTools/Extensions/RectangleExtensions.cs
+++ b/src/MacroTools/Extensions/RectangleExtensions.cs
@@ -24,7 +24,7 @@ namespace MacroTools.Extensions
     }
 
     /// <summary>
-    /// Prepares units owned by <paramref name="owningPlayer"/> within the specified <paramref name="rectangle"/> according to
+    /// Prepares neutral passive units within the specified <paramref name="rectangle"/> according to
     /// the provided <see cref="RescuePreparationMode"/>.
     /// </summary>
     /// <param name="rectangle">The rectangle in which to prepare units.</param>
@@ -33,7 +33,7 @@ namespace MacroTools.Extensions
     /// <para/>
     /// The unit gets rescued if <paramref name="filter"/> returns true, else it does not get rescued.
     /// </param>
-    /// <returns>Returns all <paramref name="owningPlayer"/> units in the specified rectangle. Default is neutral passive.</returns>
+    /// <returns>Returns all neutral passive units not matching the <paramref name="filter"/> in the specified rectangle.</returns>
     public static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, RescuePreparationMode rescuePreparationMode, Func<unit, bool>? filter = null)
     {
      
@@ -69,7 +69,7 @@ namespace MacroTools.Extensions
     /// <param name="hideUnits">If true, prepared units are hidden.</param>
     /// <param name="hideStructures">If true, prepared structures are hidden.</param>
     /// <param name="filter"></param>
-    /// <returns>All Neutral Passive units in the specified rectangle.</returns>
+    /// <returns>Returns all neutral passive units not matching the <paramref name="filter"/> in the specified rectangle.</returns>
     private static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, bool makeInvulnerable, bool hideUnits, bool hideStructures, Func<unit, bool> filter)
     {
       var group = new GroupWrapper()

--- a/src/WarcraftLegacies.Source/Quests/Fel Horde/QuestDarkPortalOpen.cs
+++ b/src/WarcraftLegacies.Source/Quests/Fel Horde/QuestDarkPortalOpen.cs
@@ -1,0 +1,92 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using MacroTools.QuestSystem;
+using MacroTools.QuestSystem.UtilityStructs;
+using System.Collections.Generic;
+using WarcraftLegacies.Source.Quests.Forsaken;
+using WarcraftLegacies.Source.Setup.Legends;
+using WCSharp.Shared.Data;
+using static War3Api.Common;
+
+namespace WarcraftLegacies.Source.Quests.FelHorde
+{
+  /// <summary>
+  /// Destroy <see cref="LegendDraenei.LegendExodarship"/> to be able to use the dark portal
+  /// </summary>
+  public class QuestDarkPortalOpen : QuestData
+  {
+    private readonly unit _portalController;
+    private readonly unit _innerWaygate1;
+    private readonly unit _innerWaygate2;
+    private readonly unit _innerWaygate3;
+    private readonly unit _outerWaygate1;
+    private readonly unit _outerWaygate2;
+    private readonly unit _outerWaygate3;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestUndercity"/>.
+    /// </summary>
+    /// <param name="portalController"></param>
+    /// <param name="innerWaygate1">A Waygate in inside outland, next to the dark portal</param>
+    /// <param name="innerWaygate2">A Waygate in inside outland, next to the dark portal.</param>
+    /// <param name="innerWaygate3">A Waygate in inside outland, next to the dark portal</param>
+    /// <param name="outerWaygate1">A Waygate in outside outland, next to the dark portal</param>
+    /// <param name="outerWaygate2">A Waygate in outside outland, next to the dark portal</param>
+    /// <param name="outerWaygate3">A Waygate in outside outland, next to the dark portal</param>
+    public QuestDarkPortalOpen(unit portalController, unit innerWaygate1, unit innerWaygate2, unit innerWaygate3, unit outerWaygate1, unit outerWaygate2, unit outerWaygate3)
+      : base("The Dark Portal Opens", "The Dark Portal has been opened", "ReplaceableTextures\\CommandButtons\\BTNDarkPortal.blp")
+    {
+      _portalController = portalController;
+      _innerWaygate1 = innerWaygate1;
+      _innerWaygate2 = innerWaygate2;
+      _innerWaygate3 = innerWaygate3;
+      _outerWaygate1 = outerWaygate1.Show(false);
+      _outerWaygate2 = outerWaygate2.Show(false);
+      _outerWaygate3 = outerWaygate3.Show(false);
+      AddObjective(new ObjectiveTime(6));
+      AddObjective(new ObjectiveExpire(785));
+      AddObjective(new ObjectiveLegendDead(LegendDraenei.LegendExodarship));
+      //AddObjective(new ObjectiveSelfExists());
+      ResearchId = Constants.UPGRADE_R04X_QUEST_COMPLETED_FORSAKEN_INDEPENDANCE;
+      Global = true;
+    }
+
+
+    /// <inheritdoc />
+    protected override string CompletionPopup =>
+      "The Dark Portal is now open.";
+
+    /// <inheritdoc />
+    protected override string RewardDescription =>
+      "The Dark Portal is now open";
+
+    /// <inheritdoc />
+    protected override void OnFail(Faction completingFaction)
+    {
+      OpenPortal();
+    }
+
+    /// <inheritdoc />
+    protected override void OnComplete(Faction completingFaction)
+    {
+      OpenPortal();
+    }
+
+    private void OpenPortal()
+    {
+      _portalController.SetInvulnerable(false);
+      _innerWaygate1.SetWaygateDestination(Regions.Dark_Portal_Exit_1.Center);
+      _innerWaygate2.SetWaygateDestination(Regions.Dark_Portal_Exit_2.Center);
+      _innerWaygate3.SetWaygateDestination(Regions.Dark_Portal_Exit_3.Center);
+      _outerWaygate1
+        .Show(true)
+        .SetWaygateDestination(Regions.Dark_Portal_Entrance_1.Center);
+      _outerWaygate2
+        .Show(true)
+        .SetWaygateDestination(Regions.Dark_Portal_Entrance_2.Center);
+      _outerWaygate3
+        .Show(true)
+        .SetWaygateDestination(Regions.Dark_Portal_Entrance_3.Center);
+    }
+  }
+}

--- a/src/WarcraftLegacies.Source/Quests/Fel Horde/QuestHellfireCitadel.cs
+++ b/src/WarcraftLegacies.Source/Quests/Fel Horde/QuestHellfireCitadel.cs
@@ -4,18 +4,25 @@ using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
-using MacroTools.Wrappers;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Fel_Horde
 {
+  /// <summary>
+  /// Drive the Draenai out of Outland, take control of various control points in outland and upgrade main to t3 in order to unlock Hellfire Citadel.
+  /// </summary>
   public sealed class QuestHellfireCitadel : QuestData
   {
     private readonly List<unit> _demonGates;
     private readonly List<unit> _rescueUnits = new();
 
-    //Todo: mediocre flavour
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="rescueRect"></param>
+    /// <param name="demonGates"></param>
+    /// <param name="prerequisites"></param>
     public QuestHellfireCitadel(Rectangle rescueRect, List<unit> demonGates, IEnumerable<QuestData> prerequisites) : base("The Citadel",
       "The clans holding Hellfire Citadel do not respect Magtheridon's authority yet, capture a large part of Outland to finally establish Magtheridon as the undisputable king of Outland",
       "ReplaceableTextures\\CommandButtons\\BTNFelOrcFortress.blp")
@@ -25,33 +32,50 @@ namespace WarcraftLegacies.Source.Quests.Fel_Horde
         AddObjective(new ObjectiveCompleteQuest(prerequisite));
       AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(Constants.UNIT_N01J_ZANGARMARSH_15GOLD_MIN)));
       AddObjective(new ObjectiveControlPoint(ControlPointManager.GetFromUnitType(Constants.UNIT_N02N_BLADE_S_EDGE_MOUNTAINS_15GOLD_MIN)));
-      AddObjective(new ObjectiveUpgrade(FourCC("o030"), FourCC("o02Y")));
+      AddObjective(new ObjectiveUpgrade(Constants.UNIT_O030_FORTRESS_FEL_HORDE, Constants.UNIT_O02Y_GREAT_HALL_FEL_HORDE));
       AddObjective(new ObjectiveExpire(1450));
       AddObjective(new ObjectiveSelfExists());
       ResearchId = Constants.UPGRADE_R00P_QUEST_COMPLETED_THE_CITADEL;
-      foreach (var unit in new GroupWrapper().EnumUnitsInRect(rescueRect).EmptyToList())
-        if (GetOwningPlayer(unit) == Player(PLAYER_NEUTRAL_AGGRESSIVE))
-          _rescueUnits.Add(unit);
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable, Player(PLAYER_NEUTRAL_AGGRESSIVE));
+      foreach (var unit in _rescueUnits)
+        SetUnitOwner(unit, Player(PLAYER_NEUTRAL_PASSIVE), false);
       Required = true;
     }
 
-    //Todo: bad flavor
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override string CompletionPopup =>
       "Hellfire Citadel has been subjugated, and its military is now free to assist the Fel Horde.";
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override string RewardDescription =>
       "Control of all units in Hellfire Citadel and enable Kargath to be trained at the altar";
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override void OnComplete(Faction completingFaction)
     {
-      foreach (var unit in _demonGates) unit.Rescue(completingFaction.Player);
-      foreach (var unit in _rescueUnits) unit.Rescue(completingFaction.Player);
+      if(completingFaction.Player != null)
+      {
+        completingFaction.Player.RescueGroup(_rescueUnits);
+        completingFaction.Player.RescueGroup(_demonGates);
+      }
       if (GetLocalPlayer() == completingFaction.Player) PlayThematicMusic("war3mapImported\\FelTheme.mp3");
     }
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override void OnFail(Faction completingFaction)
     {
-      foreach (var unit in _rescueUnits) unit.Rescue(Player(PLAYER_NEUTRAL_AGGRESSIVE));
+      if (completingFaction.Player != null)
+      {
+        Player(PLAYER_NEUTRAL_AGGRESSIVE).RescueGroup(_rescueUnits);
+      }      
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Fel Horde/QuestHellfireCitadel.cs
+++ b/src/WarcraftLegacies.Source/Quests/Fel Horde/QuestHellfireCitadel.cs
@@ -15,7 +15,7 @@ namespace WarcraftLegacies.Source.Quests.Fel_Horde
   public sealed class QuestHellfireCitadel : QuestData
   {
     private readonly List<unit> _demonGates;
-    private readonly List<unit> _rescueUnits = new();
+    private readonly List<unit> _rescueUnits;
 
     /// <summary>
     /// 
@@ -36,9 +36,7 @@ namespace WarcraftLegacies.Source.Quests.Fel_Horde
       AddObjective(new ObjectiveExpire(1450));
       AddObjective(new ObjectiveSelfExists());
       ResearchId = Constants.UPGRADE_R00P_QUEST_COMPLETED_THE_CITADEL;
-      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable, Player(PLAYER_NEUTRAL_AGGRESSIVE));
-      foreach (var unit in _rescueUnits)
-        SetUnitOwner(unit, Player(PLAYER_NEUTRAL_PASSIVE), false);
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable);
       Required = true;
     }
 

--- a/src/WarcraftLegacies.Source/Quests/Lordaeron/QuestCapitalCity.cs
+++ b/src/WarcraftLegacies.Source/Quests/Lordaeron/QuestCapitalCity.cs
@@ -17,15 +17,16 @@ namespace WarcraftLegacies.Source.Quests.Lordaeron
   {
     private readonly List<unit> _rescueUnits = new();
     private readonly unit _unitToMakeInvulnerable;
-
+    private readonly Legend _uther;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="QuestCapitalCity"/> class.
     /// </summary>
     /// <param name="rescueRect"></param>
     /// <param name="unitToMakeInvulnerable"></param>
+    /// <param name="uther"></param>
     /// <param name="prequisites"></param>
-    public QuestCapitalCity(Rectangle rescueRect, unit unitToMakeInvulnerable, IEnumerable<QuestData> prequisites) :
+    public QuestCapitalCity(Rectangle rescueRect, unit unitToMakeInvulnerable, Legend uther, IEnumerable<QuestData> prequisites) :
       base("Hearthlands",
         "The territories of Lordaeron are fragmented. Regain control of the old Alliance's hold to secure the kingdom.",
         "ReplaceableTextures\\CommandButtons\\BTNCastle.blp")
@@ -37,8 +38,9 @@ namespace WarcraftLegacies.Source.Quests.Lordaeron
       AddObjective(new ObjectiveSelfExists());
       ResearchId = Constants.UPGRADE_R04Y_QUEST_COMPLETED_HEARTHLANDS;
       _unitToMakeInvulnerable = unitToMakeInvulnerable;
+      _uther = uther;
       Func<unit, bool> rescueUnitFilter = (unit whichUnit) => { return GetUnitTypeId(whichUnit) != Constants.UNIT_N08F_UNDERCITY_ENTRANCE; };
-      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures, null, rescueUnitFilter);
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures, rescueUnitFilter);
       Required = true;
     }
 
@@ -63,7 +65,7 @@ namespace WarcraftLegacies.Source.Quests.Lordaeron
       SetUnitInvulnerable(_unitToMakeInvulnerable, true);
       if (GetLocalPlayer() == completingFaction.Player)
         PlayThematicMusic("war3mapImported\\CapitalCity.mp3");
-      LegendLordaeron.Uther.AddUnitDependency(LegendLordaeron.CapitalPalace.Unit);
+      _uther.AddUnitDependency(LegendLordaeron.CapitalPalace.Unit);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Lordaeron/QuestCapitalCity.cs
+++ b/src/WarcraftLegacies.Source/Quests/Lordaeron/QuestCapitalCity.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
@@ -14,7 +15,7 @@ namespace WarcraftLegacies.Source.Quests.Lordaeron
   /// </summary>
   public sealed class QuestCapitalCity : QuestData
   {
-    private readonly List<unit> _rescueUnits;
+    private readonly List<unit> _rescueUnits = new();
     private readonly unit _unitToMakeInvulnerable;
 
 
@@ -36,7 +37,8 @@ namespace WarcraftLegacies.Source.Quests.Lordaeron
       AddObjective(new ObjectiveSelfExists());
       ResearchId = Constants.UPGRADE_R04Y_QUEST_COMPLETED_HEARTHLANDS;
       _unitToMakeInvulnerable = unitToMakeInvulnerable;
-      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures);
+      Func<unit, bool> rescueUnitFilter = (unit whichUnit) => { return GetUnitTypeId(whichUnit) != Constants.UNIT_N08F_UNDERCITY_ENTRANCE; };
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures, null, rescueUnitFilter);
       Required = true;
     }
 
@@ -56,11 +58,12 @@ namespace WarcraftLegacies.Source.Quests.Lordaeron
     /// <inheritdoc/>
     protected override void OnComplete(Faction completingFaction)
     {
-      completingFaction.Player?.RescueGroup(_rescueUnits);
+      if (completingFaction.Player != null)
+        completingFaction.Player.RescueGroup(_rescueUnits);
       SetUnitInvulnerable(_unitToMakeInvulnerable, true);
       if (GetLocalPlayer() == completingFaction.Player)
         PlayThematicMusic("war3mapImported\\CapitalCity.mp3");
-      LegendLordaeron.Uther?.AddUnitDependency(LegendLordaeron.CapitalPalace.Unit);
+      LegendLordaeron.Uther.AddUnitDependency(LegendLordaeron.CapitalPalace.Unit);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/FelHordeQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/FelHordeQuestSetup.cs
@@ -1,9 +1,10 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using MacroTools;
 using WarcraftLegacies.Source.Quests.Fel_Horde;
 using WCSharp.Shared.Data;
 using static WarcraftLegacies.Source.Setup.FactionSetup.FelHordeSetup;
 using static War3Api.Common;
+using WarcraftLegacies.Source.Quests.FelHorde;
 
 namespace WarcraftLegacies.Source.Setup.QuestSetup
 {
@@ -24,7 +25,17 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
         preplacedUnitSystem.GetUnit(Constants.UNIT_N081_UNFOCUSED_DEMON_GATE_T0, Regions.DemonGate3.Center),
         preplacedUnitSystem.GetUnit(Constants.UNIT_N081_UNFOCUSED_DEMON_GATE_T0, Regions.Demongate_1.Center)
       }, new[] { shattrahMassacre }));
-
+     
+      FelHorde.AddQuest(new QuestDarkPortalOpen(
+        preplacedUnitSystem.GetUnit(Constants.UNIT_N05J_DARK_PORTAL_AURA_CONTROL_NEXUS, new Point(3703, -26045)),
+        preplacedUnitSystem.GetUnit(Constants.UNIT_N036_DARK_PORTAL, Regions.Dark_Portal_Entrance_1.Center),
+        preplacedUnitSystem.GetUnit(Constants.UNIT_N036_DARK_PORTAL, Regions.Dark_Portal_Entrance_2.Center),
+        preplacedUnitSystem.GetUnit(Constants.UNIT_N036_DARK_PORTAL, Regions.Dark_Portal_Entrance_3.Center),
+        preplacedUnitSystem.GetUnit(Constants.UNIT_N036_DARK_PORTAL, Regions.Dark_Portal_Exit_1.Center),
+        preplacedUnitSystem.GetUnit(Constants.UNIT_N036_DARK_PORTAL, Regions.Dark_Portal_Exit_2.Center),
+        preplacedUnitSystem.GetUnit(Constants.UNIT_N036_DARK_PORTAL, Regions.Dark_Portal_Exit_3.Center)));
+      
+    
       FelHorde.AddQuest(new QuestBlackrock(Regions.BlackrockUnlock, new[] { questKilsorrow, questHellfireCitadel }));
       FelHorde.AddQuest(new QuestFelHordeKillIronforge());
       FelHorde.AddQuest(new QuestFelHordeKillStormwind());

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/LordaeronQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/LordaeronQuestSetup.cs
@@ -18,15 +18,15 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
     {
       var lordaeron = LordaeronSetup.Lordaeron;
       var kingTerenas = LegendLordaeron.Terenas?.Unit;
-
-      if (lordaeron != null && kingTerenas != null)
+      var uther = LegendLordaeron.Uther;
+      if (lordaeron != null && kingTerenas != null && uther != null)
       {
         var questStrahnbrad = new QuestStrahnbrad(Regions.StrahnbradUnlock);
         var questStratholme = new QuestStratholme(Regions.StratholmeUnlock, preplacedUnitSystem);
         lordaeron.AddQuest(questStratholme);
         lordaeron.StartingQuest = questStratholme;
         lordaeron.AddQuest(questStrahnbrad);
-        lordaeron.AddQuest(new QuestCapitalCity(Regions.Terenas, kingTerenas,
+        lordaeron.AddQuest(new QuestCapitalCity(Regions.Terenas, kingTerenas, uther,
           new QuestData[]
           {
           questStrahnbrad,


### PR DESCRIPTION
added `owningPlayer` and `filter` to `RectangleExtensions`. `owningPlayer` allows rescuing units other than neutral passive
 `filter` allows an arbitrary `Func<unit,bool>`  to be passed in. Each unit found in the rectangle is evaluated.  When `filter` returns true the unit is rescued and it is not when `filter` returns false.
I made both parameters optional mainly because I didn't want to change every single call to to this method.
I've assigned default values to both of them so that it still works the same for all existing calls as before
