### PR TITLE
solved #498

### DIFF
--- a/src/MacroTools/Extensions/RectangleExtensions.cs
+++ b/src/MacroTools/Extensions/RectangleExtensions.cs
@@ -24,7 +24,7 @@ namespace MacroTools.Extensions
     }
 
     /// <summary>
-    /// Prepares neutral passive units within the specified <paramref name="rectangle"/> according to
+    /// Prepares units belonging to <paramref name="owningPlayer"/> within the specified <paramref name="rectangle"/> according to
     /// the provided <see cref="RescuePreparationMode"/>.
     /// </summary>
     /// <param name="rectangle">The rectangle in which to prepare units.</param>
@@ -32,16 +32,18 @@ namespace MacroTools.Extensions
     /// <param name="filter">A function that is applied to each unit found in <paramref name="rectangle"/>.
     /// The unit gets rescued if and only if <paramref name="filter"/> returns true.
     /// </param>
-    /// <returns>Returns all neutral passive units not matching the <paramref name="filter"/> in the specified rectangle.</returns>
-    public static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, RescuePreparationMode rescuePreparationMode, Func<unit, bool>? filter = null)
+    /// <param name="owningPlayer">Player the units inside the specified rectangle belong to. The default value is neutral passive.</param>
+    /// <returns>Returns all units belonging to <paramref name="owningPlayer"/> and not matching the <paramref name="filter"/> in the specified rectangle.</returns>
+    public static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, RescuePreparationMode rescuePreparationMode, Func<unit, bool>? filter = null, player? owningPlayer = null)
     {
       filter ??= _ => true;
+      owningPlayer ??= Player(PLAYER_NEUTRAL_PASSIVE);
       return rescuePreparationMode switch
       {
-        RescuePreparationMode.None => PrepareUnitsForRescue(rectangle, false, false, false, filter),
-        RescuePreparationMode.Invulnerable => PrepareUnitsForRescue(rectangle, true, false, false, filter),
-        RescuePreparationMode.HideNonStructures => PrepareUnitsForRescue(rectangle, true, true, false, filter),
-        RescuePreparationMode.HideAll => PrepareUnitsForRescue(rectangle, true, true, true, filter),
+        RescuePreparationMode.None => PrepareUnitsForRescue(rectangle, false, false, false, filter, owningPlayer),
+        RescuePreparationMode.Invulnerable => PrepareUnitsForRescue(rectangle, true, false, false, filter, owningPlayer),
+        RescuePreparationMode.HideNonStructures => PrepareUnitsForRescue(rectangle, true, true, false, filter, owningPlayer),
+        RescuePreparationMode.HideAll => PrepareUnitsForRescue(rectangle, true, true, true, filter, owningPlayer),
         _ => throw new ArgumentException($"{nameof(rescuePreparationMode)} is not implemented for this function.",
           nameof(rescuePreparationMode))
       };
@@ -56,12 +58,12 @@ namespace MacroTools.Extensions
     /// <param name="hideStructures">If true, prepared structures are hidden.</param>
     /// <param name="filter"></param>
     /// <returns>Returns all neutral passive units not matching the <paramref name="filter"/> in the specified rectangle.</returns>
-    private static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, bool makeInvulnerable, bool hideUnits, bool hideStructures, Func<unit, bool> filter)
+    private static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, bool makeInvulnerable, bool hideUnits, bool hideStructures, Func<unit, bool> filter, player owningPlayer)
     {
       var group = new GroupWrapper()
         .EnumUnitsInRect(rectangle)
         .EmptyToList()
-        .Where(x => x.OwningPlayer() == Player(PLAYER_NEUTRAL_PASSIVE) && filter.Invoke(x))
+        .Where(x => x.OwningPlayer() == owningPlayer && filter.Invoke(x))
         .ToList();
       foreach (var unit in group)
       {

--- a/src/MacroTools/Extensions/RectangleExtensions.cs
+++ b/src/MacroTools/Extensions/RectangleExtensions.cs
@@ -22,9 +22,9 @@ namespace MacroTools.Extensions
       SetSoundPosition(soundHandle, GetRectCenterX(region.Rect), GetRectCenterY(region.Rect), 0);
       RegisterStackedSound(soundHandle, true, width, height);
     }
-
+   
     /// <summary>
-    /// Prepares units belonging to <paramref name="owningPlayer"/> within the specified <paramref name="rectangle"/> according to
+    /// Prepares neutral passive units within the specified <paramref name="rectangle"/> according to
     /// the provided <see cref="RescuePreparationMode"/>.
     /// </summary>
     /// <param name="rectangle">The rectangle in which to prepare units.</param>
@@ -32,18 +32,16 @@ namespace MacroTools.Extensions
     /// <param name="filter">A function that is applied to each unit found in <paramref name="rectangle"/>.
     /// The unit gets rescued if and only if <paramref name="filter"/> returns true.
     /// </param>
-    /// <param name="owningPlayer">Player the units inside the specified rectangle belong to. The default value is neutral passive.</param>
-    /// <returns>Returns all units belonging to <paramref name="owningPlayer"/> and not matching the <paramref name="filter"/> in the specified rectangle.</returns>
-    public static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, RescuePreparationMode rescuePreparationMode, Func<unit, bool>? filter = null, player? owningPlayer = null)
+    /// <returns>Returns all neutral passive units not matching the <paramref name="filter"/> in the specified rectangle.</returns>
+    public static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, RescuePreparationMode rescuePreparationMode, Func<unit, bool>? filter = null)
     {
       filter ??= _ => true;
-      owningPlayer ??= Player(PLAYER_NEUTRAL_PASSIVE);
       return rescuePreparationMode switch
       {
-        RescuePreparationMode.None => PrepareUnitsForRescue(rectangle, false, false, false, filter, owningPlayer),
-        RescuePreparationMode.Invulnerable => PrepareUnitsForRescue(rectangle, true, false, false, filter, owningPlayer),
-        RescuePreparationMode.HideNonStructures => PrepareUnitsForRescue(rectangle, true, true, false, filter, owningPlayer),
-        RescuePreparationMode.HideAll => PrepareUnitsForRescue(rectangle, true, true, true, filter, owningPlayer),
+        RescuePreparationMode.None => PrepareUnitsForRescue(rectangle, false, false, false, filter),
+        RescuePreparationMode.Invulnerable => PrepareUnitsForRescue(rectangle, true, false, false, filter),
+        RescuePreparationMode.HideNonStructures => PrepareUnitsForRescue(rectangle, true, true, false, filter),
+        RescuePreparationMode.HideAll => PrepareUnitsForRescue(rectangle, true, true, true, filter),
         _ => throw new ArgumentException($"{nameof(rescuePreparationMode)} is not implemented for this function.",
           nameof(rescuePreparationMode))
       };
@@ -58,12 +56,12 @@ namespace MacroTools.Extensions
     /// <param name="hideStructures">If true, prepared structures are hidden.</param>
     /// <param name="filter"></param>
     /// <returns>Returns all neutral passive units not matching the <paramref name="filter"/> in the specified rectangle.</returns>
-    private static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, bool makeInvulnerable, bool hideUnits, bool hideStructures, Func<unit, bool> filter, player owningPlayer)
+    private static List<unit> PrepareUnitsForRescue(this Rectangle rectangle, bool makeInvulnerable, bool hideUnits, bool hideStructures, Func<unit, bool> filter)
     {
       var group = new GroupWrapper()
         .EnumUnitsInRect(rectangle)
         .EmptyToList()
-        .Where(x => x.OwningPlayer() == owningPlayer && filter.Invoke(x))
+        .Where(x => x.OwningPlayer() == Player(PLAYER_NEUTRAL_PASSIVE) && filter.Invoke(x))
         .ToList();
       foreach (var unit in group)
       {

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestConquerKul.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestConquerKul.cs
@@ -1,56 +1,95 @@
-using MacroTools.Extensions;
-using MacroTools.FactionSystem;
+﻿using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
+using System.Collections.Generic;
+using WarcraftLegacies.Source.Setup;
+using WarcraftLegacies.Source.Setup.FactionSetup;
 using WarcraftLegacies.Source.Setup.Legends;
+using WCSharp.Shared.Data;
 using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Zandalar
 {
+  /// <summary>
+  /// Destroy <see cref="LegendKultiras.LegendBoralus"/> without losing <see cref="LegendNeutral.Dazaralor"/> 
+  /// </summary>
   public sealed class QuestConquerKul : QuestData
   {
-    private static readonly int QuestResearchId = FourCC("R08D");
-
-    public QuestConquerKul() : base("Conquer Boralus",
+    private readonly QuestData _completeOnFailQuest;
+    private readonly List<QuestData> _failOnFailQuests;
+    private readonly Rectangle _onFailSpawnRect;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestConquerKul"/> class
+    /// </summary>
+    /// <param name="onFailSpawnRect"></param>
+    /// <param name="completeOnFailQuest">Quest that gets completed upon failing <see cref="QuestConquerKul"/>.</param>
+    /// <param name="failOnFailQuests">Quests that are failed upon failing <see cref="QuestConquerKul"/>. </param>
+    public QuestConquerKul(Rectangle onFailSpawnRect, QuestData completeOnFailQuest, List<QuestData> failOnFailQuests) : base("Conquer Boralus",
       "The Kul'tiran people and their fleet have been a threat to the Zandalari Empire for ages, it is time to put them to rest.",
       "ReplaceableTextures\\CommandButtons\\BTNGalleonIcon.blp")
     {
       AddObjective(new ObjectiveControlLegend(LegendNeutral.Dazaralor, true));
       AddObjective(new ObjectiveLegendDead(LegendKultiras.LegendBoralus));
-      ResearchId = QuestResearchId;
+      ResearchId = Constants.UPGRADE_R08D_QUEST_COMPLETED_CONQUER_BORALUS;
+      _onFailSpawnRect = onFailSpawnRect;
+      _completeOnFailQuest = completeOnFailQuest;
+      _failOnFailQuests = failOnFailQuests;
+      Required = true;
     }
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override string CompletionPopup => "Before setting sails we need to conquer Kul'tiras";
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override string RewardDescription => "Unlock shipyards";
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override string FailurePopup => "Zandalar has fallen.";
 
-    protected override string PenaltyDescription => "You can no longer build shipyards, but you unlock Zulfarrak";
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override string PenaltyDescription => "You lose everything you control and can no longer build shipyards, but you unlock Zul'Farrak";
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnComplete(Faction whichFaction)
+    {
+      if (whichFaction.Player != null)
+        whichFaction.Player.AddGold(750);
+      
+      KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
+      ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override void OnFail(Faction completingFaction)
     {
-      @group tempGroup = CreateGroup();
-      GroupEnumUnitsInRect(tempGroup, Regions.Zulfarrak.Rect, null);
-      unit u = FirstOfGroup(tempGroup);
-      while (true)
+      completingFaction.Obliterate();
+      if (completingFaction.Player != null)
       {
-        if (u == null) break;
-
-        if (GetOwningPlayer(u) == Player(PLAYER_NEUTRAL_PASSIVE) ||
-            GetOwningPlayer(u) == Player(PLAYER_NEUTRAL_AGGRESSIVE))
-        {
-          if (IsUnitType(u, UNIT_TYPE_HERO))
-            KillUnit(u);
-          else
-            u.Rescue(completingFaction.Player);
-        }
-
-        GroupRemoveUnit(tempGroup, u);
-        u = FirstOfGroup(tempGroup);
+        _completeOnFailQuest.Progress = QuestProgress.Complete;
+        foreach (var quest in _failOnFailQuests)
+          quest.Progress = QuestProgress.Failed;
+               
+        LegendTroll.LEGEND_PRIEST.ForceCreate(completingFaction.Player, new Point(_onFailSpawnRect.Center.X, _onFailSpawnRect.Center.Y), 110);
+        LegendTroll.LEGEND_RASTAKHAN.ForceCreate(completingFaction.Player, new Point(_onFailSpawnRect.Center.X, _onFailSpawnRect.Center.Y), 110);
+        if (GetLocalPlayer() == completingFaction.Player)
+          SetCameraPosition(_onFailSpawnRect.Center.X, _onFailSpawnRect.Center.Y);
+        completingFaction.Player.AddGold(1500);
+        completingFaction.Player.AddLumber(2000);
       }
-
-      DestroyGroup(tempGroup);
+      KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
+      ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestConquerKul.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestConquerKul.cs
@@ -1,7 +1,6 @@
 ﻿using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
-using System.Collections.Generic;
 using WarcraftLegacies.Source.Setup;
 using WarcraftLegacies.Source.Setup.FactionSetup;
 using WarcraftLegacies.Source.Setup.Legends;
@@ -16,15 +15,15 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
   public sealed class QuestConquerKul : QuestData
   {
     private readonly QuestData _completeOnFailQuest;
-    private readonly List<QuestData> _failOnFailQuests;
+    private readonly QuestData _failOnFailQuest;
     private readonly Rectangle _onFailSpawnRect;
     /// <summary>
     /// Initializes a new instance of the <see cref="QuestConquerKul"/> class
     /// </summary>
     /// <param name="onFailSpawnRect"></param>
     /// <param name="completeOnFailQuest">Quest that gets completed upon failing <see cref="QuestConquerKul"/>.</param>
-    /// <param name="failOnFailQuests">Quests that are failed upon failing <see cref="QuestConquerKul"/>. </param>
-    public QuestConquerKul(Rectangle onFailSpawnRect, QuestData completeOnFailQuest, List<QuestData> failOnFailQuests) : base("Conquer Boralus",
+    /// <param name="failOnFailQuest">Quest that is failed upon failing <see cref="QuestConquerKul"/>. </param>
+    public QuestConquerKul(Rectangle onFailSpawnRect, QuestData completeOnFailQuest, QuestData failOnFailQuest) : base("Conquer Boralus",
       "The Kul'tiran people and their fleet have been a threat to the Zandalari Empire for ages, it is time to put them to rest.",
       "ReplaceableTextures\\CommandButtons\\BTNGalleonIcon.blp")
     {
@@ -33,54 +32,41 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
       ResearchId = Constants.UPGRADE_R08D_QUEST_COMPLETED_CONQUER_BORALUS;
       _onFailSpawnRect = onFailSpawnRect;
       _completeOnFailQuest = completeOnFailQuest;
-      _failOnFailQuests = failOnFailQuests;
+      _failOnFailQuest = failOnFailQuest;
       Required = true;
     }
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override string CompletionPopup => "Before setting sails we need to conquer Kul'tiras";
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
+    /// <inheritdoc/>>
     protected override string RewardDescription => "Unlock shipyards";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override string FailurePopup => "Zandalar has fallen.";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override string PenaltyDescription => "You lose everything you control and can no longer build shipyards, but you unlock Zul'Farrak";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override void OnComplete(Faction whichFaction)
     {
       if (whichFaction.Player != null)
         whichFaction.Player.AddGold(750);
-      
+
       KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
       ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
     }
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override void OnFail(Faction completingFaction)
     {
       completingFaction.Obliterate();
       if (completingFaction.Player != null)
       {
         _completeOnFailQuest.Progress = QuestProgress.Complete;
-        foreach (var quest in _failOnFailQuests)
-          quest.Progress = QuestProgress.Failed;
-               
+        _failOnFailQuest.Progress = QuestProgress.Failed;
+
         LegendTroll.LEGEND_PRIEST.ForceCreate(completingFaction.Player, new Point(_onFailSpawnRect.Center.X, _onFailSpawnRect.Center.Y), 110);
         LegendTroll.LEGEND_RASTAKHAN.ForceCreate(completingFaction.Player, new Point(_onFailSpawnRect.Center.X, _onFailSpawnRect.Center.Y), 110);
         if (GetLocalPlayer() == completingFaction.Player)

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestGoldenFleet.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestGoldenFleet.cs
@@ -22,14 +22,11 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
       Required = true;
       
     }
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
+
+    /// <inheritdoc/>>
     protected override string CompletionPopup => "Rastakhan is now trainable and Direhorn are available.";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override string RewardDescription => "Rastakhan is trainable at the altar and Direhorns are trainable";
 
   }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestGoldenFleet.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestGoldenFleet.cs
@@ -1,30 +1,36 @@
-using MacroTools.FactionSystem;
-using MacroTools.QuestSystem;
+﻿using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
-using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Zandalar
 {
+
+  /// <summary>
+  /// Train 5 Golden Vessels to unlock a hero and a unit
+  /// </summary>
   public sealed class QuestGoldenFleet : QuestData
   {
-    private static readonly int QuestResearchId = FourCC("R06W"); //This research is given when the quest is completed
 
-    protected override string CompletionPopup => "Rastakhan is now trainable and Direhorn are available.";
-
-    protected override string RewardDescription =>
-      "Rastakhan is trainable at the altar and Direhorns are trainable";
-
-    protected override void OnAdd(Faction whichFaction)
-    {
-      whichFaction.ModObjectLimit(QuestResearchId, 1);
-    }
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestConquerKul"/> class
+    /// </summary>
     public QuestGoldenFleet() : base("The Golden Fleet",
       "The King has ordered for the greatest armada in the world. The construction of the Golden Fleet has begun!",
       "ReplaceableTextures\\CommandButtons\\BTNTrollConjurer.blp")
     {
-      AddObjective(new ObjectiveTrain(FourCC("o04W"), FourCC("o049"), 5));
-      ResearchId = QuestResearchId;
+      AddObjective(new ObjectiveTrain(Constants.UNIT_O04W_GOLDEN_VESSEL_ZANDALAR, Constants.UNIT_O049_GOLDEN_DOCK_ZANDALAR, 5));
+      ResearchId = Constants.UPGRADE_R06W_QUEST_COMPLETED_THE_GOLDEN_FLEET;
+      Required = true;
+      
     }
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override string CompletionPopup => "Rastakhan is now trainable and Direhorn are available.";
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override string RewardDescription => "Rastakhan is trainable at the altar and Direhorns are trainable";
+
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestGundrak.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestGundrak.cs
@@ -12,9 +12,9 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
   /// </summary>
   public sealed class QuestGundrak : QuestData
   {
-    private static readonly int GundrakResearch = Constants.UPGRADE_R02Q_QUEST_COMPLETED_THE_DRAKKARI_FORTRESS_WARSONG;
-    private static readonly int WarlordId = Constants.UNIT_NFTK_WARLORD_WARSONG;
-    private static readonly int TrollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
+    private const int _gundrakResearch = Constants.UPGRADE_R02Q_QUEST_COMPLETED_THE_DRAKKARI_FORTRESS_WARSONG;
+    private const int _warlordId = Constants.UNIT_NFTK_WARLORD_WARSONG;
+    private const int _trollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
 
 
     /// <summary>
@@ -28,36 +28,28 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
       
     }
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override string CompletionPopup =>
       "Gundrak has fallen. The Drakkari trolls lend their might to the Zandalari.";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary
     protected override string RewardDescription =>
-      $"300 gold and the ability to train {GetObjectName(WarlordId)}s from the {GetObjectName(TrollShrineId)}.";
+      $"300 gold and the ability to train {GetObjectName(_warlordId)}s from the {GetObjectName(_trollShrineId)}.";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary
     protected override void OnComplete(Faction completingFaction)
     {
       if (completingFaction.Player != null)
       {
-        SetPlayerTechResearched(completingFaction.Player, GundrakResearch, 1);
+        SetPlayerTechResearched(completingFaction.Player, _gundrakResearch, 1);
         completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
       }
     }
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary
     protected override void OnAdd(Faction whichFaction)
     {
-      whichFaction.ModObjectLimit(GundrakResearch, Faction.UNLIMITED);
+      whichFaction.ModObjectLimit(_gundrakResearch, Faction.UNLIMITED);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestGundrak.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestGundrak.cs
@@ -1,39 +1,63 @@
-using MacroTools.FactionSystem;
+﻿using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
 using WarcraftLegacies.Source.Setup.Legends;
-using static War3Api.Common; 
+using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Zandalar
 {
+
+  /// <summary>
+  /// Capture <see cref="LegendNeutral.Gundrak"/> to unlock a new unit
+  /// </summary>
   public sealed class QuestGundrak : QuestData
   {
-    private static readonly int GundrakResearch = FourCC("R02Q");
-    private static readonly int WarlordId = FourCC("nftk");
-    private static readonly int TrollShrineId = FourCC("o04X");
-    
-    protected override string CompletionPopup =>
-      "Gundrak has fallen. The Drakkari trolls lend their might to the Zandalari.";
+    private static readonly int GundrakResearch = Constants.UPGRADE_R02Q_QUEST_COMPLETED_THE_DRAKKARI_FORTRESS_WARSONG;
+    private static readonly int WarlordId = Constants.UNIT_NFTK_WARLORD_WARSONG;
+    private static readonly int TrollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
 
-    protected override string RewardDescription =>
-      $"300 gold and the ability to train {GetObjectName(WarlordId)}s from the {GetObjectName(TrollShrineId)}.";
 
-    protected override void OnComplete(Faction completingFaction)
-    {
-      SetPlayerTechResearched(completingFaction.Player, GundrakResearch, 1);
-      completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
-    }
-
-    protected override void OnAdd(Faction whichFaction)
-    {
-      whichFaction.ModObjectLimit(GundrakResearch, Faction.UNLIMITED);
-    }
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestGundrak"/> class
+    /// </summary>
     public QuestGundrak() : base("The Drakkari Fortress",
       "The Drakkari troll of Gundrak believe their fortress to be impregnable. Capture it to gain their loyalty.",
       "ReplaceableTextures\\CommandButtons\\BTNTerrorTroll.blp")
     {
       AddObjective(new ObjectiveControlLegend(LegendNeutral.Gundrak, false));
+      
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override string CompletionPopup =>
+      "Gundrak has fallen. The Drakkari trolls lend their might to the Zandalari.";
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary
+    protected override string RewardDescription =>
+      $"300 gold and the ability to train {GetObjectName(WarlordId)}s from the {GetObjectName(TrollShrineId)}.";
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary
+    protected override void OnComplete(Faction completingFaction)
+    {
+      if (completingFaction.Player != null)
+      {
+        SetPlayerTechResearched(completingFaction.Player, GundrakResearch, 1);
+        completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
+      }
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary
+    protected override void OnAdd(Faction whichFaction)
+    {
+      whichFaction.ModObjectLimit(GundrakResearch, Faction.UNLIMITED);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestJinthaAlor.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestJinthaAlor.cs
@@ -11,12 +11,12 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
   /// </summary>
   public sealed class QuestJinthaAlor : QuestData
   {
-    private static readonly int JinthaalorResearch = Constants.UPGRADE_R02N_QUEST_COMPLETED_THE_ANCIENT_EGG_WARSONG;
-    private static readonly int BearRiderId = Constants.UNIT_O02K_BEAR_RIDER_WARSONG;
-    private static readonly int TrollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
+    private const int _jinthaalorResearch = Constants.UPGRADE_R02N_QUEST_COMPLETED_THE_ANCIENT_EGG_WARSONG;
+    private const int _bearRiderId = Constants.UNIT_O02K_BEAR_RIDER_WARSONG;
+    private const int _trollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
 
     /// <summary>
-    /// 
+    /// Initializes a new instance of the <see cref="QuestJinthaAlor"/> class
     /// </summary>
     public QuestJinthaAlor() : base("The Ancient Egg",
       "The Vilebranch trolls of Jintha'Alor are controlled by their fear of the Soulflayer's egg, hidden within their shrine. Smash it to gain their loyalty.",
@@ -25,37 +25,27 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
       AddObjective(new ObjectiveControlLegend(LegendNeutral.Jinthaalor, false));
     }
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override string CompletionPopup =>
       "Jintha'Alor has fallen. The Vilebranch trolls lend their might to the Zandalari";
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
+    /// <inheritdoc/>>
     protected override string RewardDescription =>
-      "Control of Jintha'Alor, 300 gold tribute and the ability to train " + GetObjectName(BearRiderId) +
-      "s from the " + GetObjectName(TrollShrineId);
-
-    /// <summary>
+      "Control of Jintha'Alor, 300 gold tribute and the ability to train " + GetObjectName(_bearRiderId) +
+      "s from the " + GetObjectName(_trollShrineId);
     /// <inheritdoc/>
-    /// </summary>
     protected override void OnComplete(Faction completingFaction)
     {
       if (completingFaction.Player != null)
       {
-        SetPlayerTechResearched(completingFaction.Player, JinthaalorResearch, 1);
+        SetPlayerTechResearched(completingFaction.Player, _jinthaalorResearch, 1);
         completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
       }
     }
-
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override void OnAdd(Faction whichFaction)
     {
-      whichFaction.ModObjectLimit(JinthaalorResearch, Faction.UNLIMITED);
+      whichFaction.ModObjectLimit(_jinthaalorResearch, Faction.UNLIMITED);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestJinthaAlor.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestJinthaAlor.cs
@@ -1,41 +1,61 @@
-using MacroTools.FactionSystem;
+﻿using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
 using WarcraftLegacies.Source.Setup.Legends;
-using static War3Api.Common; 
+using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Zandalar
 {
+  /// <summary>
+  /// Capture <see cref="LegendNeutral.Jinthaalor"/> to unlock a new unit
+  /// </summary>
   public sealed class QuestJinthaAlor : QuestData
   {
-    private static readonly int JinthaalorResearch = FourCC("R02N");
-    private static readonly int BearRiderId = FourCC("o02K");
-    private static readonly int TrollShrineId = FourCC("o04X");
-    
-    protected override string CompletionPopup =>
-      "Jintha'Alor has fallen. The Vilebranch trolls lend their might to the Zandalari";
+    private static readonly int JinthaalorResearch = Constants.UPGRADE_R02N_QUEST_COMPLETED_THE_ANCIENT_EGG_WARSONG;
+    private static readonly int BearRiderId = Constants.UNIT_O02K_BEAR_RIDER_WARSONG;
+    private static readonly int TrollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
 
-    protected override string RewardDescription =>
-      "Control of Jintha'Alor, 300 gold tribute and the ability to train " + GetObjectName(BearRiderId) +
-      "s from the " + GetObjectName(TrollShrineId);
-
-    protected override void OnComplete(Faction completingFaction)
-    {
-      SetPlayerTechResearched(completingFaction.Player, JinthaalorResearch, 1);
-      completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
-    }
-
-    protected override void OnAdd(Faction whichFaction)
-    {
-      whichFaction.ModObjectLimit(JinthaalorResearch, Faction.UNLIMITED);
-    }
-
-
+    /// <summary>
+    /// 
+    /// </summary>
     public QuestJinthaAlor() : base("The Ancient Egg",
       "The Vilebranch trolls of Jintha'Alor are controlled by their fear of the Soulflayer's egg, hidden within their shrine. Smash it to gain their loyalty.",
       "ReplaceableTextures\\CommandButtons\\BTNForestTrollShadowPriest.blp")
     {
       AddObjective(new ObjectiveControlLegend(LegendNeutral.Jinthaalor, false));
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override string CompletionPopup =>
+      "Jintha'Alor has fallen. The Vilebranch trolls lend their might to the Zandalari";
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override string RewardDescription =>
+      "Control of Jintha'Alor, 300 gold tribute and the ability to train " + GetObjectName(BearRiderId) +
+      "s from the " + GetObjectName(TrollShrineId);
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnComplete(Faction completingFaction)
+    {
+      if (completingFaction.Player != null)
+      {
+        SetPlayerTechResearched(completingFaction.Player, JinthaalorResearch, 1);
+        completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
+      }
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnAdd(Faction whichFaction)
+    {
+      whichFaction.ModObjectLimit(JinthaalorResearch, Faction.UNLIMITED);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZandalar.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZandalar.cs
@@ -31,29 +31,21 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
       Required = true;
     }
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override string CompletionPopup =>
       "The City of Gold is now yours to command and has joined the Zandalari";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override string RewardDescription =>
       "Control of all units in Dazar'alor and enables the Golden Fleet to be built";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override void OnFail(Faction completingFaction)
     {
       Player(PLAYER_NEUTRAL_AGGRESSIVE).RescueGroup(_rescueUnits);
     }
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override void OnComplete(Faction completingFaction)
     {
       if(completingFaction.Player != null)

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZandalar.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZandalar.cs
@@ -1,51 +1,66 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
-using MacroTools.Wrappers;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
 
-
 namespace WarcraftLegacies.Source.Quests.Zandalar
 {
+  /// <summary>
+  /// Fully upgrade your main to unlock Zan
+  /// </summary>
   public sealed class QuestZandalar : QuestData
   {
-    private readonly List<unit> _rescueUnits = new();
+    private readonly List<unit> _rescueUnits;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestZandalar"/> class
+    /// </summary>
+    /// <param name="rescueRect"></param>
     public QuestZandalar(Rectangle rescueRect) : base("City of Gold", "We need to regain control of our land.",
       "ReplaceableTextures\\CommandButtons\\BTNBloodTrollMage.blp")
     {
-      AddObjective(new ObjectiveResearch(FourCC("R04R"), FourCC("o03Z")));
-      AddObjective(new ObjectiveUpgrade(FourCC("o03Z"), FourCC("o03Y")));
+      AddObjective(new ObjectiveResearch(Constants.UPGRADE_R04R_FORTIFIED_HULLS_UNIVERSAL_UPGRADE, Constants.UNIT_O03Z_FORTRESS_ZANDALAR));
+      AddObjective(new ObjectiveUpgrade(Constants.UNIT_O03Z_FORTRESS_ZANDALAR, Constants.UNIT_O03Y_STRONGHOLD_ZANDALAR));
       AddObjective(new ObjectiveExpire(900));
       AddObjective(new ObjectiveSelfExists());
-      ResearchId = FourCC("R04W");
-
-      foreach (var unit in new GroupWrapper().EnumUnitsInRect(rescueRect).EmptyToList())
-        if (GetOwningPlayer(unit) == Player(PLAYER_NEUTRAL_PASSIVE))
-        {
-          SetUnitInvulnerable(unit, true);
-          _rescueUnits.Add(unit);
-        }
+      ResearchId = Constants.UPGRADE_R04W_QUEST_COMPLETED_CITY_OF_GOLD;
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable);
+      Required = true;
     }
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override string CompletionPopup =>
       "The City of Gold is now yours to command and has joined the Zandalari";
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override string RewardDescription =>
-      "Control of all units in Zandalar and enables the Golden Fleet to be built";
+      "Control of all units in Dazar'alor and enables the Golden Fleet to be built";
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override void OnFail(Faction completingFaction)
     {
-      foreach (var unit in _rescueUnits) unit.Rescue(Player(PLAYER_NEUTRAL_AGGRESSIVE));
+      Player(PLAYER_NEUTRAL_AGGRESSIVE).RescueGroup(_rescueUnits);
     }
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override void OnComplete(Faction completingFaction)
     {
-      foreach (var unit in _rescueUnits) unit.Rescue(completingFaction.Player);
-      if (GetLocalPlayer() == completingFaction.Player) PlayThematicMusic("war3mapImported\\ZandalarTheme.mp3");
+      if(completingFaction.Player != null)
+        completingFaction.Player.RescueGroup(_rescueUnits);
+      
+      if (GetLocalPlayer() == completingFaction.Player) 
+        PlayThematicMusic("war3mapImported\\ZandalarTheme.mp3");
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZulfarrak.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZulfarrak.cs
@@ -1,9 +1,8 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
-using MacroTools.Wrappers;
 using WarcraftLegacies.Source.Setup.Legends;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
@@ -11,38 +10,59 @@ using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Zandalar
 {
+  /// <summary>
+  /// Capture Zul'Farrak to unlock Gahz'rilla as a hero/>
+  /// </summary>
   public sealed class QuestZulfarrak : QuestData
   {
     private const int GAHZRILLA_ID = Constants.UNIT_H06Q_DEMIGOD_WARSONG;
-    private readonly List<unit> _rescueUnits = new();
-
+    private readonly List<unit> _rescueUnits;
+    private readonly List<unit> _killUnits;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestZulfarrak"/> class
+    /// </summary>
+    /// <param name="rescueRect"></param>
     public QuestZulfarrak(Rectangle rescueRect) : base("Fury of the Sands",
       "The Sandfury Trolls of Zul'farrak are openly hostile to visitors, but they share a common heritage with the Zandalari Trolls. An adequate display of force could bring them around.",
       "ReplaceableTextures\\CommandButtons\\BTNDarkTroll.blp")
     {
       ResearchId = Constants.UPGRADE_R02F_QUEST_COMPLETED_FURY_OF_THE_SANDS_WARSONG;
       AddObjective(new ObjectiveControlLegend(LegendNeutral.Zulfarrak, false));
-      foreach (var unit in new GroupWrapper().EnumUnitsInRect(rescueRect).EmptyToList())
-        if (GetOwningPlayer(unit) == Player(PLAYER_NEUTRAL_PASSIVE))
-        {
-          SetUnitInvulnerable(unit, true);
-          _rescueUnits.Add(unit);
-        }
+      AddObjective(new ObjectiveLegendReachRect(LegendTroll.LEGEND_PRIEST, rescueRect, "Zul'Farrak"));
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures);
+      _killUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures, (unit => GetUnitTypeId(unit) != GetUnitTypeId(LegendNeutral.Zulfarrak.Unit)), Player(PLAYER_NEUTRAL_AGGRESSIVE));
     }
 
+    /// <summary>
+    ///<inheritdoc/>
+    /// </summary>
     protected override string CompletionPopup =>
       $"Zul'farrak has fallen. The Sandfury trolls lend their might to the Zandalari.";
 
+    /// <summary>
+    ///<inheritdoc/>
+    /// </summary>
     protected override string RewardDescription =>
       "Control of Zul'farrak, 300 gold tribute, enable to train Storm Wyrm and you can summon the hero Gahz'rilla from the Altar of Conquerors";
 
+    /// <summary>
+    ///<inheritdoc/>
+    /// </summary>
     protected override void OnComplete(Faction completingFaction)
     {
-      foreach (var unit in _rescueUnits) unit.Rescue(completingFaction.Player);
-      completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
-      SetUnitOwner(LegendNeutral.Zulfarrak.Unit, completingFaction.Player, true);
+      if (completingFaction.Player != null)
+      {
+        SetUnitOwner(LegendNeutral.Zulfarrak.Unit, completingFaction.Player, true);
+        completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
+        completingFaction.Player.RescueGroup(_rescueUnits);
+        foreach (var unit in _killUnits)
+          unit.Kill();    
+      }
     }
 
+    /// <summary>
+    ///<inheritdoc/>
+    /// </summary>
     protected override void OnAdd(Faction whichFaction)
     {
       whichFaction.ModObjectLimit(GAHZRILLA_ID, 1);

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZulfarrak.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZulfarrak.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
+using MacroTools.Wrappers;
 using WarcraftLegacies.Source.Setup.Legends;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
@@ -15,9 +17,10 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
   /// </summary>
   public sealed class QuestZulfarrak : QuestData
   {
-    private const int GAHZRILLA_ID = Constants.UNIT_H06Q_DEMIGOD_WARSONG;
+    private const int _ghazrilla_id = Constants.UNIT_H06Q_DEMIGOD_WARSONG;
     private readonly List<unit> _rescueUnits;
     private readonly List<unit> _killUnits;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="QuestZulfarrak"/> class
     /// </summary>
@@ -30,24 +33,18 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
       AddObjective(new ObjectiveControlLegend(LegendNeutral.Zulfarrak, false));
       AddObjective(new ObjectiveLegendReachRect(LegendTroll.LEGEND_PRIEST, rescueRect, "Zul'Farrak"));
       _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures);
-      _killUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures, (unit => GetUnitTypeId(unit) != GetUnitTypeId(LegendNeutral.Zulfarrak.Unit)), Player(PLAYER_NEUTRAL_AGGRESSIVE));
+      _killUnits = new GroupWrapper().EnumUnitsInRect(rescueRect).EmptyToList().Where(x => x.OwningPlayer() == Player(PLAYER_NEUTRAL_AGGRESSIVE)).ToList();
     }
 
-    /// <summary>
-    ///<inheritdoc/>
-    /// </summary>
+    /// <inheritdoc/>
     protected override string CompletionPopup =>
       $"Zul'farrak has fallen. The Sandfury trolls lend their might to the Zandalari.";
 
-    /// <summary>
-    ///<inheritdoc/>
-    /// </summary>
+    /// <inheritdoc/>
     protected override string RewardDescription =>
       "Control of Zul'farrak, 300 gold tribute, enable to train Storm Wyrm and you can summon the hero Gahz'rilla from the Altar of Conquerors";
 
-    /// <summary>
-    ///<inheritdoc/>
-    /// </summary>
+    /// <inheritdoc/>>
     protected override void OnComplete(Faction completingFaction)
     {
       if (completingFaction.Player != null)
@@ -60,12 +57,10 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
       }
     }
 
-    /// <summary>
-    ///<inheritdoc/>
-    /// </summary>
+    /// <inheritdoc/>
     protected override void OnAdd(Faction whichFaction)
     {
-      whichFaction.ModObjectLimit(GAHZRILLA_ID, 1);
+      whichFaction.ModObjectLimit(_ghazrilla_id, 1);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZulgurub.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZulgurub.cs
@@ -11,9 +11,9 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
   /// </summary>
   public sealed class QuestZulgurub : QuestData
   {
-    private static readonly int ZulgurubResearch = Constants.UPGRADE_R02M_QUEST_COMPLETED_THE_HEART_OF_HAKKAR_WARSONG;
-    private static readonly int TrollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
-    private static readonly int RavagerId = Constants.UNIT_O021_RAVAGER_WARSONG;
+    private const int _zulgurubResearch = Constants.UPGRADE_R02M_QUEST_COMPLETED_THE_HEART_OF_HAKKAR_WARSONG;
+    private const int _trollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
+    private const int _ravagerId = Constants.UNIT_O021_RAVAGER_WARSONG;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="QuestZulgurub"/> class
@@ -25,34 +25,27 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
       AddObjective(new ObjectiveControlLegend(LegendNeutral.Zulgurub, false));
     }
 
-    /// <summary>
+
     /// <inheritdoc/>
-    /// </summary>
     protected override string CompletionPopup => "Zul'gurub has fallen. The Gurubashi trolls lend their might to the Zandalari.";
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
-    protected override string RewardDescription => "300 gold and the ability to train " + GetObjectName(RavagerId) + "s from the " + GetObjectName(TrollShrineId);
+    protected override string RewardDescription => "300 gold and the ability to train " + GetObjectName(_ravagerId) + "s from the " + GetObjectName(_trollShrineId);
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
+    /// <inheritdoc/>>
     protected override void OnComplete(Faction completingFaction)
     {
       if(completingFaction.Player != null)
       {
-        SetPlayerTechResearched(completingFaction.Player, ZulgurubResearch, 1);
+        SetPlayerTechResearched(completingFaction.Player, _zulgurubResearch, 1);
         completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
       }
     }
 
-    /// <summary>
     /// <inheritdoc/>
-    /// </summary>
     protected override void OnAdd(Faction whichFaction)
     {
-      whichFaction.ModObjectLimit(ZulgurubResearch, Faction.UNLIMITED);
+      whichFaction.ModObjectLimit(_zulgurubResearch, Faction.UNLIMITED);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZulgurub.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestZulgurub.cs
@@ -1,4 +1,4 @@
-using MacroTools.FactionSystem;
+﻿using MacroTools.FactionSystem;
 using MacroTools.QuestSystem;
 using MacroTools.QuestSystem.UtilityStructs;
 using WarcraftLegacies.Source.Setup.Legends;
@@ -6,35 +6,53 @@ using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Zandalar
 {
+  /// <summary>
+  /// Capture <see cref="LegendNeutral.Zulgurub"/> to unlock a new unit
+  /// </summary>
   public sealed class QuestZulgurub : QuestData
   {
-    private static readonly int ZulgurubResearch = FourCC("R02M");
-    private static readonly int TrollShrineId = FourCC("o04X");
-    private static readonly int RavagerId = FourCC("o021");
+    private static readonly int ZulgurubResearch = Constants.UPGRADE_R02M_QUEST_COMPLETED_THE_HEART_OF_HAKKAR_WARSONG;
+    private static readonly int TrollShrineId = Constants.UNIT_O04X_LOA_SHRINE_ZANDALAR;
+    private static readonly int RavagerId = Constants.UNIT_O021_RAVAGER_WARSONG;
 
-    protected override string CompletionPopup =>
-      "Zul'gurub has fallen. The Gurubashi trolls lend their might to the Zandalari.";
-
-    protected override string RewardDescription =>
-      "300 gold and the ability to train " + GetObjectName(RavagerId) + "s from the " +
-      GetObjectName(TrollShrineId);
-
-    protected override void OnComplete(Faction completingFaction)
-    {
-      SetPlayerTechResearched(completingFaction.Player, ZulgurubResearch, 1);
-      completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
-    }
-
-    protected override void OnAdd(Faction whichFaction)
-    {
-      whichFaction.ModObjectLimit(ZulgurubResearch, Faction.UNLIMITED);
-    }
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestZulgurub"/> class
+    /// </summary>
     public QuestZulgurub() : base("Heart of Hakkar",
       "The Gurubashi trolls of Zul'Gurub follow the sacred Heart of Hakkar, hidden within their shrine. Capture it to gain their loyalty.",
       "ReplaceableTextures\\CommandButtons\\BTNTrollRavager.blp")
     {
       AddObjective(new ObjectiveControlLegend(LegendNeutral.Zulgurub, false));
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override string CompletionPopup => "Zul'gurub has fallen. The Gurubashi trolls lend their might to the Zandalari.";
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override string RewardDescription => "300 gold and the ability to train " + GetObjectName(RavagerId) + "s from the " + GetObjectName(TrollShrineId);
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnComplete(Faction completingFaction)
+    {
+      if(completingFaction.Player != null)
+      {
+        SetPlayerTechResearched(completingFaction.Player, ZulgurubResearch, 1);
+        completingFaction.Player.AdjustPlayerState(PLAYER_STATE_RESOURCE_GOLD, 300);
+      }
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnAdd(Faction whichFaction)
+    {
+      whichFaction.ModObjectLimit(ZulgurubResearch, Faction.UNLIMITED);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/TrollQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/TrollQuestSetup.cs
@@ -1,3 +1,5 @@
+﻿using MacroTools.QuestSystem;
+using System.Collections.Generic;
 using WarcraftLegacies.Source.Quests.Zandalar;
 using WarcraftLegacies.Source.Setup.FactionSetup;
 
@@ -8,14 +10,19 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
     public static void Setup()
     {
       var zandalar = ZandalarSetup.Zandalar;
-
-      zandalar.StartingQuest = zandalar.AddQuest(new QuestZandalar(Regions.ZandalarUnlock));
-      zandalar.AddQuest(new QuestConquerKul());
-      zandalar.AddQuest(new QuestZulfarrak(Regions.Zulfarrak));
-      zandalar.AddQuest(new QuestZulgurub());
-      zandalar.AddQuest(new QuestGundrak());
-      zandalar.AddQuest(new QuestJinthaAlor());
-      zandalar.AddQuest(new QuestHakkar());
+      if (zandalar != null)
+      {
+        var questZulFarrak = new QuestZulfarrak(Regions.Zulfarrak);
+        var questZandalar = new QuestZandalar(Regions.ZandalarUnlock);
+        zandalar.StartingQuest = zandalar.AddQuest(questZandalar);
+      
+        zandalar.AddQuest(questZulFarrak);
+        zandalar.AddQuest(new QuestConquerKul(Regions.Zulfarrak, questZulFarrak, new List<QuestData> {questZandalar}));
+        zandalar.AddQuest(new QuestZulgurub());
+        zandalar.AddQuest(new QuestGundrak());
+        zandalar.AddQuest(new QuestJinthaAlor());
+        zandalar.AddQuest(new QuestHakkar());
+      }
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/TrollQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/TrollQuestSetup.cs
@@ -1,6 +1,4 @@
-﻿using MacroTools.QuestSystem;
-using System.Collections.Generic;
-using WarcraftLegacies.Source.Quests.Zandalar;
+﻿using WarcraftLegacies.Source.Quests.Zandalar;
 using WarcraftLegacies.Source.Setup.FactionSetup;
 
 namespace WarcraftLegacies.Source.Setup.QuestSetup
@@ -17,7 +15,7 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
         zandalar.StartingQuest = zandalar.AddQuest(questZandalar);
       
         zandalar.AddQuest(questZulFarrak);
-        zandalar.AddQuest(new QuestConquerKul(Regions.Zulfarrak, questZulFarrak, new List<QuestData> {questZandalar}));
+        zandalar.AddQuest(new QuestConquerKul(Regions.Zulfarrak, questZulFarrak, questZandalar));
         zandalar.AddQuest(new QuestZulgurub());
         zandalar.AddQuest(new QuestGundrak());
         zandalar.AddQuest(new QuestJinthaAlor());


### PR DESCRIPTION
Extended RectangleExtensions to allow rescuing units of any player. This is needed so that if `QuestConquerKul` is failed and you spawn in ZulFarrak, you don't have to fight all the enemies there.
Refactored other Zandalar Quests to be more in line with the new style and updated them to be in line with the vJass version.

 

