### PR TITLE
issue #298

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,6 @@ healthchecksdb
 
 # Project specific
 /artifacts
+
+# User specific appsettings
+appsettings.*.json


### PR DESCRIPTION
User specific Appsettings get created on launch. 
User specific Appsettings override default Appsettings. 
User specific Appsettings added manually to gitignore

I manually added the file to gitignore with the * pattern so that any user specific appsetting file will be ignored. 

I figured this would be much easier than checking the file manually every time the map launches or executing some git command in an external shell and read its output.

Not sure of the quality of this code but it does work _on my machine_ , so there is that.

Closes #298.