### PR TITLE
#646 Kultiras quest refactor and rework

### DIFF
--- a/src/WarcraftLegacies.Source/Quests/Zandalar/QuestConquerKul.cs
+++ b/src/WarcraftLegacies.Source/Quests/Zandalar/QuestConquerKul.cs
@@ -57,7 +57,6 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
     protected override void OnComplete(Faction whichFaction)
     {
       whichFaction.Player?.AddGold(750);
-      KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
       ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
     }
 
@@ -90,8 +89,6 @@ namespace WarcraftLegacies.Source.Quests.Zandalar
         GeneralHelpers.CreateUnits(completingFaction.Player, Constants.UNIT_O04W_GOLDEN_VESSEL_ZANDALAR,
           Regions.TrollSecondChance.Center.X, Regions.TrollSecondChance.Center.Y, 270, 3);
       }
-
-      KultirasSetup.Kultiras?.Player?.SetTeam(TeamSetup.Alliance);
       ZandalarSetup.Zandalar?.Player?.SetTeam(TeamSetup.Horde);
     }
   }

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/KultirasSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/KultirasSetup.cs
@@ -19,14 +19,14 @@ namespace WarcraftLegacies.Source.Setup.FactionSetup
           {
             StartingGold = 150,
             StartingLumber = 500,
-            IntroText = @"You are playing as the hardy island |cff008000Kingdom of Kul'tiras|r.
+            IntroText = @"You are playing as the maritime human kingdom |cff008000Kingdom of Kul'tiras|r.
 
-You start in the Balor islands, but you must move quickly to gain control your capital and the Gold Mines on Kul'tiras island. 
+You start on Balor island, but you must move quickly. Viscious foes are threatening the islands.
 
-The Zandalari Trolls mounting an attack from the South so be ready, the fight will be bloody.
+Unite the Admiralty of Kul'Tiras by eliminating these foes and seizing control of your territory.
 
-Once you have conquered the Zandalari Empire, set sail to help your allies."
-          };
+Once you have established your kingdom, set sail to help your allies on the main land in the south."
+        };
 
       //Structures
       Kultiras.ModObjectLimit(FourCC("h062"), Faction.UNLIMITED); //Town Hall

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendKulTiras.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendKulTiras.cs
@@ -1,6 +1,5 @@
-using MacroTools;
+﻿using MacroTools;
 using MacroTools.Extensions;
-using MacroTools.FactionSystem;
 using MacroTools.LegendSystem;
 using static War3Api.Common;
 

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/KultirasQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/KultirasQuestSetup.cs
@@ -1,4 +1,4 @@
-using MacroTools;
+﻿using MacroTools;
 using WarcraftLegacies.Source.Quests.KulTiras;
 using WarcraftLegacies.Source.Setup.FactionSetup;
 
@@ -16,7 +16,6 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
       kultiras.AddQuest(new QuestSafeSea());
       kultiras.AddQuest(new QuestTheramore(Regions.Theramore));
       kultiras.AddQuest(new QuestBeyondPortal());
-      kultiras.AddQuest(new QuestJoinCrusade());
     }
   }
 }


### PR DESCRIPTION
Closes #646 

Removed second chance for Kul'Tiras in `QuestUnlockShip`. 
Removed Kul'Tiras related code in Zandalar Quests. 
Removed `QuestJoinCrusade`
Changed Kul Tiras `QuestUnlockShip` to now require capturing control points on Kul Tiras.  The flavour is to renuite the kingdom and get rid of all the threats on the islands.
Adjusted Kul'Tiras intro text to accomodate these changes.

