### PR TITLE
2 new objectives and 2 Draenai Quests for #638

### DIFF
--- a/src/MacroTools/QuestSystem/UtilityStructs/ObjectiveBuildInRect.cs
+++ b/src/MacroTools/QuestSystem/UtilityStructs/ObjectiveBuildInRect.cs
@@ -1,0 +1,84 @@
+﻿using MacroTools.Extensions;
+using System;
+using WCSharp.Events;
+using WCSharp.Shared.Data;
+using static War3Api.Common;
+
+namespace MacroTools.QuestSystem.UtilityStructs
+{
+  /// <summary>
+  /// Completed when an eligible player completes construction on a building in the specified <see cref="Rectangle"/>.
+  /// </summary>
+  public class ObjectiveBuildInRect : Objective
+  {
+    private readonly int _objectId;
+    private readonly Rectangle _targetRect;
+    private int _currentBuildCount;
+    private readonly int _targetBuildCount;
+    private string _rectName;
+
+    private int CurrentBuildCount
+    {
+      set
+      {
+        _currentBuildCount = value;
+        Description = $"Build {GetObjectName(_objectId)} ( {I2S(_currentBuildCount)} / {I2S(_targetBuildCount)} ) at {_rectName}";
+      }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectiveBuildInRect"/> class.  /// 
+    /// </summary>
+    /// <param name="targetRect"></param>
+    /// <param name="rectName"></param>
+    /// <param name="objectId"></param>
+    /// <param name="count"></param>
+    public ObjectiveBuildInRect(Rectangle targetRect, string rectName, int objectId, int count = 1)
+    {
+      _rectName = rectName;
+      _targetBuildCount = count;
+      _targetRect = targetRect;
+      _objectId = objectId;
+      DisplaysPosition = true;
+      CurrentBuildCount = 0;
+      PingPath = "MinimapQuestTurnIn";
+      PlayerUnitEvents.Register(UnitTypeEvent.Dies, OnDeath, objectId);
+      CreateTrigger()
+        .RegisterEnterRegion(targetRect)
+        .AddAction(() =>
+        {
+          var triggerUnit = GetTriggerUnit();
+          if (!IsUnitValid(triggerUnit))
+            return;
+          CurrentBuildCount = _currentBuildCount + 1;
+          if (_currentBuildCount == _targetBuildCount)
+          {
+            Progress = QuestProgress.Complete;
+          }
+        });
+    }
+
+    private void OnDeath()
+    {
+      if (Progress == QuestProgress.Complete)
+        return;
+
+      var triggerUnit = GetTriggerUnit();
+      if (!IsUnitValid(triggerUnit))
+        return;
+      var point = triggerUnit.GetPosition();
+      if (point.X > _targetRect.Left && point.X < _targetRect.Right && point.Y > _targetRect.Bottom && point.Y < _targetRect.Top)
+      {
+        CurrentBuildCount = _currentBuildCount - 1;
+        Progress = QuestProgress.Incomplete;
+      }
+    }
+
+    /// <inheritdoc />
+    public override Point Position => new(GetRectCenterX(_targetRect.Rect), GetRectCenterY(_targetRect.Rect));
+
+    private bool IsUnitValid(unit whichUnit) =>
+      EligibleFactions.Contains(whichUnit.OwningPlayer()) &&
+      (IsUnitType(whichUnit, UNIT_TYPE_STRUCTURE) && whichUnit.GetTypeId() == _objectId);
+  }
+}

--- a/src/MacroTools/QuestSystem/UtilityStructs/ObjectiveUnitReachesFullHealth.cs
+++ b/src/MacroTools/QuestSystem/UtilityStructs/ObjectiveUnitReachesFullHealth.cs
@@ -1,0 +1,51 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using WCSharp.Shared.Data;
+using static War3Api.Common;
+
+namespace MacroTools.QuestSystem.UtilityStructs
+{
+  /// <summary>
+  /// An objective that completes when a unit reaches full health and fails if it dies
+  /// </summary>
+  public class ObjectiveUnitReachesFullHealth : Objective
+  {
+    private unit _objectiveUnit { get; }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectiveUnitReachesFullHealth"/> class.
+    /// </summary>
+    /// <param name="objectiveUnit">The unit that must be brought to full hp for this objective to complete</param>
+    public ObjectiveUnitReachesFullHealth(unit objectiveUnit)
+    {
+      _objectiveUnit = objectiveUnit;
+      TargetWidget = objectiveUnit;
+      Description = $"{GetUnitName(objectiveUnit)} brought to full health";
+      DisplaysPosition = IsUnitType(objectiveUnit, UNIT_TYPE_STRUCTURE);
+      CreateTrigger()
+        .RegisterUnitEvent(objectiveUnit, EVENT_UNIT_SELECTED)
+        .AddAction(() =>
+        {
+          if (GetUnitState(_objectiveUnit, UNIT_STATE_LIFE) == GetUnitState(_objectiveUnit, UNIT_STATE_MAX_LIFE))
+            Progress = QuestProgress.Complete;
+        });
+      CreateTrigger()
+        .RegisterUnitEvent(objectiveUnit, EVENT_UNIT_DESELECTED)
+        .AddAction(() =>
+        {
+          if (GetUnitState(_objectiveUnit, UNIT_STATE_LIFE) == GetUnitState(_objectiveUnit, UNIT_STATE_MAX_LIFE))
+            Progress = QuestProgress.Complete;
+        });
+    }
+
+    /// <inheritdoc/>
+    public override Point Position => new(GetUnitX(_objectiveUnit), GetUnitY(_objectiveUnit));
+
+    internal override void OnAdd(Faction faction)
+    {
+      if (!UnitAlive(_objectiveUnit))
+        Progress = QuestProgress.Failed;
+      else if (GetUnitState(_objectiveUnit, UNIT_STATE_LIFE) == GetUnitState(_objectiveUnit, UNIT_STATE_MAX_LIFE))
+        Progress = QuestProgress.Complete;
+    }
+  }
+}

--- a/src/WarcraftLegacies.Source/Quests/Draenei/QuestRebuildCivilisation.cs
+++ b/src/WarcraftLegacies.Source/Quests/Draenei/QuestRebuildCivilisation.cs
@@ -1,0 +1,54 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using MacroTools.Libraries;
+using MacroTools.QuestSystem;
+using MacroTools.QuestSystem.UtilityStructs;
+using System.Collections.Generic;
+using WCSharp.Shared.Data;
+
+namespace WarcraftLegacies.Source.Quests.Draenei
+{
+  /// <summary>
+  /// 
+  /// </summary>
+  public class QuestRebuildCivilisation : QuestData
+  {
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestRebuildCivilisation"/> class.
+    /// </summary>
+    public QuestRebuildCivilisation(Rectangle questRect) : base("The Way Forward", "Establish a base around the Exodar in order to secure it.", "")
+    {
+      Required = true;
+      AddObjective(new ObjectiveBuildInRect(questRect, "Azuremyst isle", Constants.UNIT_U00U_CRYSTAL_PROTECTOR_DRAENEI, 2));
+      AddObjective(new ObjectiveBuildInRect(questRect, "Azuremyst isle", Constants.UNIT_O058_ALTAR_OF_LIGHT_DRAENEI, 1));
+      AddObjective(new ObjectiveBuildInRect(questRect, "Azuremyst isle", Constants.UNIT_O056_ARCANE_WELL_DRAENEI, 3));
+      AddObjective(new ObjectiveUpgrade(Constants.UNIT_O051_DIVINE_CITADEL_DRAENEI, Constants.UNIT_O02P_CRYSTAL_HALL_DRAENEI));
+      AddObjective(new ObjectiveKillAllInArea(new List<Rectangle> { questRect }, "Azuremyst isle"));
+
+      ResearchId = Constants.UPGRADE_R082_QUEST_COMPLETED_THE_SURVIVORS_OF_SHATTRAH;// Change this to current quest;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnComplete(Faction whichFaction)
+    {
+      if (whichFaction.Player != null)
+      {
+        whichFaction.Player.AddGold(500);
+        whichFaction.Player.AddLumber(200);
+      }
+    }
+
+    /// <inheritdoc/>
+    protected override string CompletionPopup => "The Exodar is secure and Maraad joins the Draenai.";
+
+    /// <inheritdoc/>
+    protected override string RewardDescription => "Gain 500 Gold, 200 Lumber and Maraad is now trainable at the altar.";
+
+    protected override void OnAdd(Faction whichFaction)
+    {
+      GeneralHelpers.CreateUnits(whichFaction.Player, Constants.UNIT_O05A_GEMCRAFTER_DRAENEI_WORKER,
+         Regions.AzuremystAmbient.Center.X, Regions.AzuremystAmbient.Center.Y, 270, 8);
+    }
+  }
+}

--- a/src/WarcraftLegacies.Source/Quests/Draenei/QuestRepairExodarHull.cs
+++ b/src/WarcraftLegacies.Source/Quests/Draenei/QuestRepairExodarHull.cs
@@ -1,0 +1,66 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using MacroTools.QuestSystem;
+using MacroTools.QuestSystem.UtilityStructs;
+using System.Collections.Generic;
+using WarcraftLegacies.Source.Setup.Legends;
+using WCSharp.Shared.Data;
+using static War3Api.Common;
+
+namespace WarcraftLegacies.Source.Quests.Draenei
+{
+  /// <summary>
+  /// Bring the exodar to full health in order to unlock the base inside
+  /// </summary>
+  public class QuestRepairExodarHull : QuestData
+  {
+
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="rescueRect"></param>
+
+    public QuestRepairExodarHull(Rectangle rescueRect) : base("A New Home", "After the disastrous voyage through the Twisting Nether, the exodar crash-landed on the Azuremyst Isles. Its hull must be repaired in order to get inside.", "")
+    {
+      Required = true;
+      AddObjective(new ObjectiveUnitReachesFullHealth(LegendDraenei.LegendExodar.Unit));
+      AddObjective(new ObjectiveResearch(Constants.UPGRADE_R04R_FORTIFIED_HULLS_UNIVERSAL_UPGRADE, Constants.UNIT_O051_DIVINE_CITADEL_DRAENEI));
+      AddObjective(new ObjectiveSelfExists());
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures);
+    }
+
+    private List<unit> _rescueUnits { get; }
+    /// <inheritdoc/>
+    protected override string CompletionPopup => "The Exodar's hull is repaired. It can now be entered again";
+
+    /// <inheritdoc/>
+    protected override string FailurePopup => "The Exodar is destroyed. It can never be repaired again.";
+
+    /// <inheritdoc/>
+    protected override string RewardDescription => "You are now able to enter the Exodar and gain access to everything inside.";
+
+    /// <inheritdoc/>
+    protected override void OnComplete(Faction whichFaction)
+    {
+      if (whichFaction.Player != null)
+        whichFaction.Player.RescueGroup(_rescueUnits);
+      else
+        Player(PLAYER_NEUTRAL_AGGRESSIVE).RescueGroup(_rescueUnits);
+
+      //Open Portals to exodar inside
+    }
+
+    /// <inheritdoc/>
+    protected override void OnFail(Faction whichFaction)
+    {
+      // Quest to repair the Exodar inside should be failed here too.
+    }
+
+    /// <inheritdoc/>
+    protected override void OnAdd(Faction whichFaction)
+    {
+      SetUnitState(LegendDraenei.LegendExodar.Unit, UNIT_STATE_LIFE, GetUnitState(LegendDraenei.LegendExodar.Unit, UNIT_STATE_MAX_LIFE) * 0.1f);
+    }
+  }
+}

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/DraeneiQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/DraeneiQuestSetup.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Generic;
-using MacroTools;
+﻿using MacroTools;
 using WarcraftLegacies.Source.Quests.Draenei;
 using WarcraftLegacies.Source.Setup.FactionSetup;
-using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Setup.QuestSetup
 {
@@ -11,14 +9,18 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
     public static void Setup(PreplacedUnitSystem preplacedUnitSystem)
     {
       var draenei = DraeneiSetup.Draenei;
-
-      draenei.AddQuest(new QuestSurvivorsShattrah());
-      draenei.AddQuest(new QuestBrokenOne());
-      draenei.AddQuest(new QuestShipArgus(
-        preplacedUnitSystem.GetUnit(Constants.UNIT_H03V_ENTRANCE_PORTAL, Regions.OutlandToArgus.Center),
-        preplacedUnitSystem.GetUnit(Constants.UNIT_H03V_ENTRANCE_PORTAL, Regions.TempestKeepSpawn.Center)
-        ));
-      draenei.AddQuest(new QuestTriumvirate());
+      if (draenei != null)
+      {
+        var questRepairHull = new QuestRepairExodarHull(Regions.Exodar_Interior_All);
+        draenei.StartingQuest = questRepairHull;
+        draenei.AddQuest(questRepairHull);
+        draenei.AddQuest(new QuestRebuildCivilisation(Regions.AzuremystAmbient));
+        draenei.AddQuest(new QuestShipArgus(
+          preplacedUnitSystem.GetUnit(Constants.UNIT_H03V_ENTRANCE_PORTAL, Regions.OutlandToArgus.Center),
+          preplacedUnitSystem.GetUnit(Constants.UNIT_H03V_ENTRANCE_PORTAL, Regions.TempestKeepSpawn.Center)
+          ));
+        draenei.AddQuest(new QuestTriumvirate());
+      }
     }
   }
 }


### PR DESCRIPTION
Added an objective to bring a unit to full health
Added an objective to build something inside a specific area 
Added a draenai quest to repair the exodar
Added a quest to establish a base on azuremyst isles

As discussed there are a couple things still missing.
The teleporters to the exodar do not spawn after completing `QuestRepairHull`
New Quest completed Researches are needed for the quests and have to tie unlocking Maraad to the completion of `QuestRebuildCivilisation`
Icons for the quest are missing.
Quest descriptions could be a lot better.
