### PR TITLE
polish and fixes for Frostwolf

### DIFF
--- a/src/MacroTools/ObjectiveSystem/Objectives/ObjectiveUnitIsDead.cs
+++ b/src/MacroTools/ObjectiveSystem/Objectives/ObjectiveUnitIsDead.cs
@@ -31,7 +31,7 @@ namespace MacroTools.ObjectiveSystem.Objectives
         return;
       }
 
-      Description = GetUnitName(Target) + "is dead.";
+      Description = GetUnitName(Target) + " is dead.";
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestDarkspear.cs
+++ b/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestDarkspear.cs
@@ -1,0 +1,49 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using MacroTools.ObjectiveSystem.Objectives;
+using MacroTools.QuestSystem;
+using System.Collections.Generic;
+using WarcraftLegacies.Source.Setup.Legends;
+using static War3Api.Common;
+
+namespace WarcraftLegacies.Source.Quests.Frostwolf
+{
+  /// <summary>
+  /// Bring <see cref="LegendFrostwolf.LegendVolJin"/> to the Echo Isles to unlock the base
+  /// </summary>
+  public sealed class QuestDarkspear : QuestData
+  {
+    private readonly List<unit> _rescueUnits = new();
+
+    /// <inheritdoc />
+    public QuestDarkspear() : base("The Darkspear Trolls",
+      "After the Darkspear trolls were rescued by Thrall, Vol'jin pledged his loyalty and service to the Horde. The trolls must now be gathered to help in the fight against the night elves.",
+      "ReplaceableTextures\\CommandButtons\\BTNSorceressMaster.blp")
+    {
+      _rescueUnits = Regions.EchoUnlock.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures);
+      AddObjective(new ObjectiveSelfExists());
+      AddObjective(new ObjectiveExpire(900));
+      AddObjective(new ObjectiveLegendInRect(LegendFrostwolf.LegendVolJin, Regions.EchoUnlock, "Echo Isles"));
+      Required = true;
+    }
+
+    /// <inheritdoc />
+    protected override string CompletionPopup => "Vol'jin has made contact with the Darkspear trolls on the Echo Isles. They are now yours to command!";
+
+    /// <inheritdoc />
+    protected override string RewardDescription => "Unlock the troll base on the Echo Isles.";
+
+    /// <inheritdoc />
+    protected override void OnFail(Faction completingFaction)
+    {
+      Player(PLAYER_NEUTRAL_AGGRESSIVE).RescueGroup(_rescueUnits);
+    }
+
+    /// <inheritdoc />
+    protected override void OnComplete(Faction completingFaction)
+    {
+      if (completingFaction.Player != null)
+        completingFaction.Player.RescueGroup(_rescueUnits);
+    }
+  }
+}

--- a/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestDarkspear.cs
+++ b/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestDarkspear.cs
@@ -13,7 +13,7 @@ namespace WarcraftLegacies.Source.Quests.Frostwolf
   /// </summary>
   public sealed class QuestDarkspear : QuestData
   {
-    private readonly List<unit> _rescueUnits = new();
+    private readonly List<unit> _rescueUnits;
 
     /// <inheritdoc />
     public QuestDarkspear() : base("The Darkspear Trolls",
@@ -22,8 +22,8 @@ namespace WarcraftLegacies.Source.Quests.Frostwolf
     {
       _rescueUnits = Regions.EchoUnlock.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures);
       AddObjective(new ObjectiveSelfExists());
-      AddObjective(new ObjectiveExpire(900));
-      AddObjective(new ObjectiveLegendInRect(LegendFrostwolf.LegendVolJin, Regions.EchoUnlock, "Echo Isles"));
+      AddObjective(new ObjectiveExpire(1455));
+      AddObjective(new ObjectiveAnyUnitInRect(Regions.EchoUnlock, "Echo Isles", true));
       Required = true;
     }
 
@@ -42,8 +42,7 @@ namespace WarcraftLegacies.Source.Quests.Frostwolf
     /// <inheritdoc />
     protected override void OnComplete(Faction completingFaction)
     {
-      if (completingFaction.Player != null)
-        completingFaction.Player.RescueGroup(_rescueUnits);
+        completingFaction.Player?.RescueGroup(_rescueUnits);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestThunderBluff.cs
+++ b/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestThunderBluff.cs
@@ -16,7 +16,7 @@ namespace WarcraftLegacies.Source.Quests.Frostwolf
   /// </summary>
   public sealed class QuestThunderBluff : QuestData
   {
-    private readonly List<unit> _rescueUnits = new();
+    private readonly List<unit> _rescueUnits;
 
     /// <inheritdoc />
     public QuestThunderBluff(PreplacedUnitSystem preplacedUnitSystem, Rectangle rescueRect) : base("The Long March",
@@ -24,7 +24,7 @@ namespace WarcraftLegacies.Source.Quests.Frostwolf
       "ReplaceableTextures\\CommandButtons\\BTNCentaurKhan.blp")
     {
       AddObjective(new ObjectiveUnitIsDead(preplacedUnitSystem.GetUnit(FourCC("ncnk"), rescueRect.Center)));
-      AddObjective(new ObjectiveLegendInRect(LegendFrostwolf.LegendCairne, rescueRect, "Thunder Bluff"));
+      AddObjective(new ObjectiveAnyUnitInRect(rescueRect, "Thunder Bluff", true));
       AddObjective(new ObjectiveExpire(1455));
       AddObjective(new ObjectiveSelfExists());
       ResearchId = Constants.UPGRADE_R05I_QUEST_COMPLETED_THE_LONG_MARCH; 

--- a/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestThunderBluff.cs
+++ b/src/WarcraftLegacies.Source/Quests/Frostwolf/QuestThunderBluff.cs
@@ -1,53 +1,59 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using MacroTools;
 using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.ObjectiveSystem.Objectives;
 using MacroTools.QuestSystem;
 using WarcraftLegacies.Source.Setup.Legends;
+using WCSharp.Shared.Data;
 using static War3Api.Common;
 
 
 namespace WarcraftLegacies.Source.Quests.Frostwolf
 {
+  /// <summary>
+  /// Kill the centaur leader in Mulgore and bring <see cref="LegendFrostwolf.LegendCairne"/> to <see cref="LegendFrostwolf.LegendThunderbluff"/> to unlock it
+  /// </summary>
   public sealed class QuestThunderBluff : QuestData
   {
     private readonly List<unit> _rescueUnits = new();
 
-    public QuestThunderBluff(PreplacedUnitSystem preplacedUnitSystem, rect rescueRect) : base("The Long March",
+    /// <inheritdoc />
+    public QuestThunderBluff(PreplacedUnitSystem preplacedUnitSystem, Rectangle rescueRect) : base("The Long March",
       "The Tauren have been wandering for too long. The plains of Mulgore would offer respite from this endless journey.",
       "ReplaceableTextures\\CommandButtons\\BTNCentaurKhan.blp")
     {
-      AddObjective(new ObjectiveUnitIsDead(preplacedUnitSystem.GetUnit(FourCC("ncnk"), Regions.ThunderBluff.Center)));
-      AddObjective(new ObjectiveAnyUnitInRect(Regions.ThunderBluff, "Thunder Bluff", true));
+      AddObjective(new ObjectiveUnitIsDead(preplacedUnitSystem.GetUnit(FourCC("ncnk"), rescueRect.Center)));
+      AddObjective(new ObjectiveLegendInRect(LegendFrostwolf.LegendCairne, rescueRect, "Thunder Bluff"));
       AddObjective(new ObjectiveExpire(1455));
       AddObjective(new ObjectiveSelfExists());
-      ResearchId = FourCC("R05I");
-
-      foreach (var unit in CreateGroup().EnumUnitsInRect(rescueRect).EmptyToList())
-        if (GetOwningPlayer(unit) == Player(PLAYER_NEUTRAL_PASSIVE))
-        {
-          SetUnitInvulnerable(unit, true);
-          _rescueUnits.Add(unit);
-        }
-
+      ResearchId = Constants.UPGRADE_R05I_QUEST_COMPLETED_THE_LONG_MARCH; 
+      _rescueUnits = rescueRect.PrepareUnitsForRescue(RescuePreparationMode.HideNonStructures);
       Required = true;
     }
 
     //todo: bad flavour
+    /// <inheritdoc />
     protected override string CompletionPopup => "The long march of the Tauren clans has ended, and they have joined forces with the Horde.";
 
+    /// <inheritdoc />
     protected override string RewardDescription => "Control of Thunder Bluff";
 
+    /// <inheritdoc />
     protected override void OnFail(Faction completingFaction)
     {
-      foreach (var unit in _rescueUnits) unit.Rescue(Player(PLAYER_NEUTRAL_AGGRESSIVE));
+      Player(PLAYER_NEUTRAL_AGGRESSIVE).RescueGroup(_rescueUnits);
     }
 
+    /// <inheritdoc />
     protected override void OnComplete(Faction completingFaction)
     {
-      foreach (var unit in _rescueUnits) unit.Rescue(completingFaction.Player);
-      if (GetLocalPlayer() == completingFaction.Player) PlayThematicMusic("war3mapImported\\TaurenTheme.mp3");
+      if (completingFaction.Player != null)
+      { 
+        completingFaction.Player.RescueGroup(_rescueUnits);
+        if (GetLocalPlayer() == completingFaction.Player) 
+          PlayThematicMusic("war3mapImported\\TaurenTheme.mp3");
+      }
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/FrostwolfSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/FrostwolfSetup.cs
@@ -22,10 +22,10 @@ namespace WarcraftLegacies.Source.Setup.FactionSetup
         ControlPointDefenderUnitTypeId = Constants.UNIT_N0B6_CONTROL_POINT_DEFENDER_FROSTWOLF,
         IntroText = @"You are playing as the honorable |cffff0000Frostwolf Clan|r.
 
-You have been shipwrecked. Gather enough resources to sail South-West to Kalimdor. Until you reach Kalimdor, you will be unable to train any more peons or research new tech. 
+Following Medihvs call to sail west and find his destiny, Thrall and his forces were shipwrecked on the coast of Kalimdor. 
 
-Once you land, you will find a Tauren caravan with a Great Hall packed in it's inventory. 
-Escort the kodo to Thunderbluff, where you will find a goldmine waiting for you."
+Establish a base and gather your troops - but make haste and move inland, for the lands are rugged and harsh and resources are scarce."
+
       };
 
       Frostwolf.ModObjectLimit(Constants.UNIT_OGRE_GREAT_HALL_FROSTWOLF, Faction.UNLIMITED);

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendFrostwolf.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendFrostwolf.cs
@@ -1,6 +1,7 @@
-using MacroTools;
+﻿using MacroTools;
 using MacroTools.FactionSystem;
 using MacroTools.LegendSystem;
+using System;
 using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Setup.Legends
@@ -10,7 +11,7 @@ namespace WarcraftLegacies.Source.Setup.Legends
     public static LegendaryHero? LegendCairne { get; private set; }
     public static LegendaryHero? LegendThrall { get; private set; }
     public static LegendaryHero? LegendRexxar { get; private set; }
-
+    public static LegendaryHero? LegendVolJin { get; private set; }
     public static Capital? LegendThunderbluff { get; private set; }
     public static Capital? LegendDarkspearhold { get; private set; }
     public static Capital? LegendOrgrimmar { get; private set; }
@@ -52,6 +53,12 @@ namespace WarcraftLegacies.Source.Setup.Legends
         StartingXp = 1800
       };
       LegendaryHeroManager.Register(LegendRexxar);
+
+      LegendVolJin = new LegendaryHero("Vol'jin")
+      {
+        UnitType = Constants.UNIT_ORKN_CHIEFTAIN_OF_THE_DARKSPEAR_TRIBE_FROSTWOLF,
+      };
+      LegendaryHeroManager.Register(LegendVolJin);
 
       LegendOrgrimmar = new Capital
       {

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/FrostwolfQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/FrostwolfQuestSetup.cs
@@ -9,13 +9,15 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
     public static void Setup(PreplacedUnitSystem preplacedUnitSystem, ArtifactSetup artifactSetup)
     {
       var frostwolf = FrostwolfSetup.Frostwolf;
-
-      frostwolf.AddQuest(new QuestThunderBluff(preplacedUnitSystem, Regions.ThunderBluff.Rect));
-      frostwolf.AddQuest(new QuestRexxar(preplacedUnitSystem));
-      frostwolf.AddQuest(new QuestDrektharsSpellbook());
-      //frostwolf.AddQuest(new QuestRoyalPlunder(Regions.HighBourne, artifactSetup.ScepterOfTheQueen));
-      frostwolf.AddQuest(new QuestFreeNerzhul());
-      frostwolf.AddQuest(new QuestWorldShaman());
+      if (frostwolf != null)
+      {
+        frostwolf.AddQuest(new QuestThunderBluff(preplacedUnitSystem, Regions.ThunderBluff));
+        frostwolf.AddQuest(new QuestRexxar(preplacedUnitSystem));
+        frostwolf.AddQuest(new QuestDarkspear());
+        frostwolf.AddQuest(new QuestDrektharsSpellbook());
+        frostwolf.AddQuest(new QuestFreeNerzhul());
+        frostwolf.AddQuest(new QuestWorldShaman());
+      }
     }
   }
 }


### PR DESCRIPTION
- Added `QuestDarkspear` to unlock the troll base on the Echo Isles - closes #794 
- Refactored and reworked `QuestThunderBluff` so that Cairne must be the one to enter Mulgore to make it more lore accurate
- Overhauled intro text to match new frostwolf start - completes Frostwolf in #754 
- Added Vol'jin as Legendary Hero