### PR TITLE
Fixes for #782 and #783

### DIFF
--- a/src/MacroTools/ObjectiveSystem/Objectives/ObjectiveCastSpell.cs
+++ b/src/MacroTools/ObjectiveSystem/Objectives/ObjectiveCastSpell.cs
@@ -1,4 +1,4 @@
-using MacroTools.QuestSystem;
+﻿using MacroTools.QuestSystem;
 using WCSharp.Events;
 using static War3Api.Common;
 
@@ -18,7 +18,7 @@ namespace MacroTools.ObjectiveSystem.Objectives
     /// <param name="holderOnly">If true, the quest holder must cast the spell themselves.</param>
     public ObjectiveCastSpell(int spellId, bool holderOnly)
     {
-      PlayerUnitEvents.Register(UnitTypeEvent.SpellFinish, OnCast, spellId);
+      PlayerUnitEvents.Register(SpellEvent.Finish, OnCast, spellId);
       if (holderOnly)
         Description = "Cast " + GetObjectName(spellId);
       else

--- a/src/WarcraftLegacies.Source/Setup/QuestSetup/ScourgeQuestSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/QuestSetup/ScourgeQuestSetup.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using MacroTools;
 using MacroTools.QuestSystem;
 using WarcraftLegacies.Source.Mechanics.Scourge.Plague;
@@ -30,11 +30,10 @@ namespace WarcraftLegacies.Source.Setup.QuestSetup
       };
       plagueParameters.PlagueCauldronSummonParameters = new List<PlagueCauldronSummonParameter>
       {
-        new(1, Constants.UNIT_U01R_APOTHECARY_FORSAKEN_CULT),
+        new(2, Constants.UNIT_UNEC_NECROMANCER_SCOURGE),
         new(2, Constants.UNIT_UACO_ACOLYTE_SCOURGE_WORKER, ScourgeSetup.Scourge),
-        new(2, Constants.UNIT_U01K_ACOLYTE_FORSAKEN_CULT_WORKER),
-        new(4, Constants.UNIT_N07S_DEADEYE_FORSAKEN_CULT),
-        new(4, Constants.UNIT_H08O_ROTGUARD_FORSAKEN),
+        new(4, Constants.UNIT_UGHO_GHOUL_SCOURGE),
+        new(4, Constants.UNIT_UCRY_CRYPT_FIEND_SCOURGE),
       };
       plagueParameters.PlagueCauldronUnitTypeId = Constants.UNIT_H02W_PLAGUE_CAULDRON;
       plagueParameters.Duration = 360;


### PR DESCRIPTION
- closes #782 (There was actually nothing wrong with the spell itself but with the spell event in `ObjectiveCastSpell`) 
- closes #783 (replaced cult units with scourge units, removed cult workers)