### PR TITLE
Remove Unit Abilities and Exact Commands

### DIFF
--- a/src/MacroTools/Cheats/CheatAddSpell.cs
+++ b/src/MacroTools/Cheats/CheatAddSpell.cs
@@ -11,6 +11,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "add";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatBuild.cs
+++ b/src/MacroTools/Cheats/CheatBuild.cs
@@ -15,6 +15,9 @@ namespace MacroTools.Cheats
 
     /// <inheritdoc />
     public override string CommandText => "build";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatControl.cs
+++ b/src/MacroTools/Cheats/CheatControl.cs
@@ -13,6 +13,9 @@ namespace MacroTools.Cheats
 
     /// <inheritdoc />
     public override string CommandText => "control";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatDestroy.cs
+++ b/src/MacroTools/Cheats/CheatDestroy.cs
@@ -11,6 +11,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "destroy";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatFaction.cs
+++ b/src/MacroTools/Cheats/CheatFaction.cs
@@ -13,6 +13,9 @@ namespace MacroTools.Cheats
 
     /// <inheritdoc />
     public override string CommandText => "faction";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatFood.cs
+++ b/src/MacroTools/Cheats/CheatFood.cs
@@ -12,6 +12,9 @@ namespace MacroTools.Cheats
 
     /// <inheritdoc />
     public override string CommandText => "food";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatGetUnitAbilities.cs
+++ b/src/MacroTools/Cheats/CheatGetUnitAbilities.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using MacroTools.CommandSystem;
+using MacroTools.Extensions;
+using static War3Api.Common;
+using static MacroTools.Libraries.GeneralHelpers;
+
+namespace MacroTools.Cheats
+{
+  /// <summary>
+  /// A <see cref="Command"/> Gets a list of abilities that the first selected unit has.
+  /// </summary>
+  public sealed class CheatGetUnitAbilities : Command
+  {
+    /// <inheritdoc />
+    public override string CommandText => "getAbilities";
+    
+    /// <inheritdoc />
+    public override bool Exact => true;
+
+    /// <inheritdoc />
+    public override int MinimumParameterCount => 0;
+
+    /// <inheritdoc />
+    public override CommandType Type => CommandType.Cheat;
+
+    /// <inheritdoc />
+    public override string Description => "Gets a list of abilities that the first selected unit has.";
+  
+    /// <inheritdoc />
+    public override string Execute(player cheater, params string[] parameters)
+    {
+      var abilityString = "";
+      var firstSelectedUnit = CreateGroup().EnumSelectedUnits(cheater).EmptyToList().First();
+      foreach (var ability in firstSelectedUnit.GetUnitAbilities())
+      {
+        abilityString += $"{BlzGetAbilityStringField(ability,ABILITY_SF_NAME)}: {BlzGetAbilityId(ability)}\n";
+      }
+      return $"{abilityString}";
+    }
+  }
+}

--- a/src/MacroTools/Cheats/CheatGod.cs
+++ b/src/MacroTools/Cheats/CheatGod.cs
@@ -15,6 +15,9 @@ namespace MacroTools.Cheats
     
     /// <inheritdoc />
     public override string CommandText => "god";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatGold.cs
+++ b/src/MacroTools/Cheats/CheatGold.cs
@@ -11,6 +11,9 @@ namespace MacroTools.Cheats
 
     /// <inheritdoc />
     public override string CommandText => "gold";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatHP.cs
+++ b/src/MacroTools/Cheats/CheatHP.cs
@@ -12,6 +12,9 @@ namespace MacroTools.Cheats
  
     /// <inheritdoc />
     public override string CommandText => "hp";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatKick.cs
+++ b/src/MacroTools/Cheats/CheatKick.cs
@@ -13,6 +13,9 @@ namespace MacroTools.Cheats
 
     /// <inheritdoc />
     public override string CommandText => "kick";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatLevel.cs
+++ b/src/MacroTools/Cheats/CheatLevel.cs
@@ -12,6 +12,9 @@ namespace MacroTools.Cheats
 
     /// <inheritdoc />
     public override string CommandText => "level";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatLumber.cs
+++ b/src/MacroTools/Cheats/CheatLumber.cs
@@ -7,6 +7,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "lumber";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatMP.cs
+++ b/src/MacroTools/Cheats/CheatMP.cs
@@ -10,6 +10,9 @@ namespace MacroTools.Cheats
     public override string CommandText => "mp";
     
     /// <inheritdoc />
+    public override bool Exact => false;
+    
+    /// <inheritdoc />
     public override int MinimumParameterCount => 1;
     
     /// <inheritdoc />

--- a/src/MacroTools/Cheats/CheatMana.cs
+++ b/src/MacroTools/Cheats/CheatMana.cs
@@ -11,6 +11,9 @@ namespace MacroTools.Cheats
     public override string CommandText => "mana";
     
     /// <inheritdoc />
+    public override bool Exact => false;
+    
+    /// <inheritdoc />
     public override int MinimumParameterCount => 1;
     
     /// <inheritdoc />

--- a/src/MacroTools/Cheats/CheatNoCD.cs
+++ b/src/MacroTools/Cheats/CheatNoCD.cs
@@ -11,6 +11,9 @@ namespace MacroTools.Cheats
     public override string CommandText => "nocd";
     
     /// <inheritdoc />
+    public override bool Exact => false;
+    
+    /// <inheritdoc />
     public override int MinimumParameterCount => 1;
     
     /// <inheritdoc />

--- a/src/MacroTools/Cheats/CheatOwner.cs
+++ b/src/MacroTools/Cheats/CheatOwner.cs
@@ -10,6 +10,9 @@ namespace MacroTools.Cheats
     public override string CommandText => "owner";
     
     /// <inheritdoc />
+    public override bool Exact => false;
+    
+    /// <inheritdoc />
     public override int MinimumParameterCount => 1;
     
     /// <inheritdoc />

--- a/src/MacroTools/Cheats/CheatQuestProgress.cs
+++ b/src/MacroTools/Cheats/CheatQuestProgress.cs
@@ -16,6 +16,9 @@ namespace MacroTools.Cheats
 
     /// <inheritdoc />
     public override string CommandText => _commandText;
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatRemove.cs
+++ b/src/MacroTools/Cheats/CheatRemove.cs
@@ -8,6 +8,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "remove";
+    
+    /// <inheritdoc />
+    public override bool Exact => true;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 0;

--- a/src/MacroTools/Cheats/CheatRemoveAllAbilities.cs
+++ b/src/MacroTools/Cheats/CheatRemoveAllAbilities.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using MacroTools.CommandSystem;
 using MacroTools.Extensions;
 using static War3Api.Common;
@@ -6,12 +8,12 @@ using static War3Api.Common;
 namespace MacroTools.Cheats
 {
   /// <summary>
-  /// A cheat that displays the position of the first selected unit.
+  /// A <see cref="Command"/> Removes all abilities from first selected unit.
   /// </summary>
-  public sealed class CheatPosition : Command
+  public sealed class CheatRemoveAllAbilities : Command
   {
     /// <inheritdoc />
-    public override string CommandText => "position";
+    public override string CommandText => "removeAllAbilities";
     
     /// <inheritdoc />
     public override bool Exact => true;
@@ -23,13 +25,14 @@ namespace MacroTools.Cheats
     public override CommandType Type => CommandType.Cheat;
 
     /// <inheritdoc />
-    public override string Description => "Displays the position of the first selected unit.";
-
+    public override string Description => "Removes all abilities from first selected unit.";
+  
     /// <inheritdoc />
     public override string Execute(player cheater, params string[] parameters)
     {
       var firstSelectedUnit = CreateGroup().EnumSelectedUnits(cheater).EmptyToList().First();
-      return $"{firstSelectedUnit.GetName()} is at position {GetUnitX(firstSelectedUnit)}, {GetUnitY(firstSelectedUnit)}.";
+      firstSelectedUnit.RemoveAllAbilities(new List<int>{1096905835,1097690998,1112498531});
+      return $"All abilities removed from {firstSelectedUnit.GetName()}";
     }
   }
 }

--- a/src/MacroTools/Cheats/CheatResearchLevel.cs
+++ b/src/MacroTools/Cheats/CheatResearchLevel.cs
@@ -11,6 +11,9 @@ namespace MacroTools.Cheats
   
     /// <inheritdoc />
     public override string CommandText => "hasresearch";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatSetResearchLevel.cs
+++ b/src/MacroTools/Cheats/CheatSetResearchLevel.cs
@@ -14,6 +14,9 @@ namespace MacroTools.Cheats
     public override string CommandText => "setresearchlevel";
     
     /// <inheritdoc />
+    public override bool Exact => false;
+    
+    /// <inheritdoc />
     public override int MinimumParameterCount => 2;
     
     /// <inheritdoc />

--- a/src/MacroTools/Cheats/CheatShore.cs
+++ b/src/MacroTools/Cheats/CheatShore.cs
@@ -13,6 +13,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "shores";
+    
+    /// <inheritdoc />
+    public override bool Exact => true;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 0;

--- a/src/MacroTools/Cheats/CheatShowQuestNames.cs
+++ b/src/MacroTools/Cheats/CheatShowQuestNames.cs
@@ -13,6 +13,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "quests";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatSpawn.cs
+++ b/src/MacroTools/Cheats/CheatSpawn.cs
@@ -12,6 +12,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "spawn";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatTeam.cs
+++ b/src/MacroTools/Cheats/CheatTeam.cs
@@ -12,6 +12,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "team";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 2;

--- a/src/MacroTools/Cheats/CheatTele.cs
+++ b/src/MacroTools/Cheats/CheatTele.cs
@@ -11,6 +11,9 @@ namespace MacroTools.Cheats
     public override string CommandText => "tele";
     
     /// <inheritdoc />
+    public override bool Exact => false;
+    
+    /// <inheritdoc />
     public override int MinimumParameterCount => 1;
     
     /// <inheritdoc />

--- a/src/MacroTools/Cheats/CheatTime.cs
+++ b/src/MacroTools/Cheats/CheatTime.cs
@@ -7,6 +7,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "time";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatUncontrol.cs
+++ b/src/MacroTools/Cheats/CheatUncontrol.cs
@@ -7,6 +7,9 @@ namespace MacroTools.Cheats
   {
     /// <inheritdoc />
     public override string CommandText => "uncontrol";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
 
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Cheats/CheatVision.cs
+++ b/src/MacroTools/Cheats/CheatVision.cs
@@ -10,6 +10,9 @@ namespace MacroTools.Cheats
     public override string CommandText => "vision";
     
     /// <inheritdoc />
+    public override bool Exact => false;
+    
+    /// <inheritdoc />
     public override int MinimumParameterCount => 1;
     
     /// <inheritdoc />

--- a/src/MacroTools/CommandSystem/Command.cs
+++ b/src/MacroTools/CommandSystem/Command.cs
@@ -11,6 +11,11 @@ namespace MacroTools.CommandSystem
     /// The command that a player can execute to run the <see cref="CommandSystem.Command"/>.
     /// </summary>
     public abstract string CommandText { get; }
+    
+    /// <summary>
+    /// Set if the command needs to be an exact match or not, commands with 0 params should be exact<see cref="CommandSystem.Command"/>.
+    /// </summary>
+    public abstract bool Exact { get; }
 
     /// <summary>
     /// The minimum number of parameters that must be supplied to this <see cref="CommandSystem.Command"/> command.

--- a/src/MacroTools/CommandSystem/CommandManager.cs
+++ b/src/MacroTools/CommandSystem/CommandManager.cs
@@ -32,7 +32,7 @@ namespace MacroTools.CommandSystem
       _registeredCommands.Add(command);
       command.OnRegister();
       CreateTrigger()
-        .RegisterSharedChatEvent(Prefix + command.CommandText, false)
+        .RegisterSharedChatEvent(Prefix + command.CommandText, command.Exact)
         .AddAction(() =>
         {
           try

--- a/src/MacroTools/Commands/Cam.cs
+++ b/src/MacroTools/Commands/Cam.cs
@@ -12,6 +12,9 @@ namespace MacroTools.Commands
   {
     /// <inheritdoc />
     public override string CommandText => "cam";
+    
+    /// <inheritdoc />
+    public override bool Exact => false;
   
     /// <inheritdoc />
     public override int MinimumParameterCount => 1;

--- a/src/MacroTools/Commands/Clear.cs
+++ b/src/MacroTools/Commands/Clear.cs
@@ -20,6 +20,9 @@ namespace MacroTools.Commands
     
     /// <inheritdoc />
     public override string CommandText => _commandText;
+    
+    /// <inheritdoc />
+    public override bool Exact => true;
   
     /// <inheritdoc />
     public override int MinimumParameterCount => 0;

--- a/src/MacroTools/Commands/Limited.cs
+++ b/src/MacroTools/Commands/Limited.cs
@@ -13,6 +13,9 @@ namespace MacroTools.Commands
   {
     /// <inheritdoc />
     public override string CommandText => "limited";
+    
+    /// <inheritdoc />
+    public override bool Exact => true;
   
     /// <inheritdoc />
     public override int MinimumParameterCount => 0;

--- a/src/MacroTools/Extensions/UnitExtensions.cs
+++ b/src/MacroTools/Extensions/UnitExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using MacroTools.LegendSystem;
 using MacroTools.Libraries;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
+using static MacroTools.Libraries.GeneralHelpers;
 
 namespace MacroTools.Extensions
 {
@@ -21,12 +23,12 @@ namespace MacroTools.Extensions
       var oldLevel = GetHeroLevel(whichUnit);
       if (newLevel > oldLevel)
         SetHeroLevel(whichUnit, newLevel, showEyeCandy);
-      else if (newLevel < oldLevel) 
+      else if (newLevel < oldLevel)
         UnitStripHeroLevel(whichUnit, oldLevel - newLevel);
 
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Determines whether or not the unit's attack can be seen in the UI window.
     /// </summary>
@@ -35,13 +37,13 @@ namespace MacroTools.Extensions
       BlzSetUnitWeaponBooleanField(whichUnit, UNIT_WEAPON_BF_ATTACK_SHOW_UI, weaponSlot, show);
       return whichUnit;
     }
-    
+
     public static unit SetUnitLevel(this unit whichUnit, int level)
     {
       BlzSetUnitIntegerField(whichUnit, UNIT_IF_LEVEL, level);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Sets a unit's armor.
     /// </summary>
@@ -50,7 +52,7 @@ namespace MacroTools.Extensions
       BlzSetUnitArmor(whichUnit, armor);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Returns the unit's maximum hit points.
     /// </summary>
@@ -60,7 +62,7 @@ namespace MacroTools.Extensions
     /// Returns the unit's current hit points.
     /// </summary>
     public static float GetHitPoints(this unit whichUnit) => GetUnitState(whichUnit, UNIT_STATE_LIFE);
-    
+
     /// <summary>
     /// Sets the unit's scaling value.
     /// </summary>
@@ -69,7 +71,7 @@ namespace MacroTools.Extensions
       SetUnitScale(whichUnit, scale, scale, scale);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Sets the unit's maximum hit points.
     /// </summary>
@@ -96,7 +98,7 @@ namespace MacroTools.Extensions
       BlzSetUnitBaseDamage(whichUnit, value, weaponSlot);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Sets the unit's number of damage dice.
     /// </summary>
@@ -105,7 +107,7 @@ namespace MacroTools.Extensions
       BlzSetUnitDiceNumber(whichUnit, value, weaponSlot);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Sets the number of sides on the unit's damage dice.
     /// </summary>
@@ -123,7 +125,7 @@ namespace MacroTools.Extensions
       BlzSetUnitSkin(whichUnit, skinUnitTypeId);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Changes the unit's name.
     /// </summary>
@@ -132,7 +134,7 @@ namespace MacroTools.Extensions
       BlzSetUnitName(whichUnit, name);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Returns true if the unit is an illusion.
     /// </summary>
@@ -152,7 +154,7 @@ namespace MacroTools.Extensions
       BlzSetUnitFacingEx(whichUnit, facing);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Determines whether or not the unit explodes on death.
     /// </summary>
@@ -161,7 +163,7 @@ namespace MacroTools.Extensions
       SetUnitExploded(whichUnit, flag);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Gets the unit's unit level if it's a unit, or hero level if it's a hero.
     /// </summary>
@@ -178,7 +180,7 @@ namespace MacroTools.Extensions
       SetUnitVertexColor(whichUnit, red, green, blue, alpha);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Causes the unit to die after the specified duration, like a summoned unit.
     /// </summary>
@@ -190,11 +192,11 @@ namespace MacroTools.Extensions
     {
       if (duration < 1)
         throw new ArgumentException($"Cannot apply a timed life with a {nameof(duration)} less than 1.");
-      
+
       UnitApplyTimedLife(whichUnit, buffId, duration);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Gets the unit's type ID as shown in the object editor.
     /// </summary>
@@ -223,11 +225,11 @@ namespace MacroTools.Extensions
       SetUnitAnimation(whichUnit, animation);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Gets the units proper name. If it doesn't have one, get their unit name instead.
     /// </summary>
-    public static string GetProperName(this unit whichUnit) => 
+    public static string GetProperName(this unit whichUnit) =>
       IsUnitType(whichUnit, UNIT_TYPE_HERO) ? GetHeroProperName(whichUnit) : GetUnitName(whichUnit);
 
     /// <summary>
@@ -243,7 +245,7 @@ namespace MacroTools.Extensions
       UnitRemoveItem(whichUnit, whichItem);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Determines whether or not the unit exists in the game world.
     /// </summary>
@@ -252,7 +254,7 @@ namespace MacroTools.Extensions
       ShowUnit(whichUnit, show);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Kill the unit instantly.
     /// </summary>
@@ -278,7 +280,7 @@ namespace MacroTools.Extensions
       PauseUnit(unit, value);
       return unit;
     }
-    
+
     /// <summary>
     /// If true, prevents the unit from moving or taking actions.
     /// </summary>
@@ -287,7 +289,7 @@ namespace MacroTools.Extensions
       BlzPauseUnitEx(unit, value);
       return unit;
     }
-    
+
     /// <summary>
     /// If true, the unit cannot be targeted by attacks or hostile abilities and cannot be damaged.
     /// </summary>
@@ -296,7 +298,7 @@ namespace MacroTools.Extensions
       SetUnitInvulnerable(unit, value);
       return unit;
     }
-    
+
     /// <summary>
     /// Removes the unit from the game permanently.
     /// </summary>
@@ -304,7 +306,7 @@ namespace MacroTools.Extensions
     {
       RemoveUnit(unit);
     }
-    
+
     /// <summary>
     /// Orders a unit to perform a specified order at a specified <see cref="Point"/>.
     /// </summary>
@@ -313,7 +315,7 @@ namespace MacroTools.Extensions
       IssuePointOrder(unit, order, target.X, target.Y);
       return unit;
     }
-    
+
     /// <summary>
     /// Orders a unit to perform a specified order on the specified target.
     /// </summary>
@@ -322,7 +324,7 @@ namespace MacroTools.Extensions
       IssueTargetOrder(unit, order, target);
       return unit;
     }
-    
+
     /// <summary>
     /// Orders a unit to perform the specified targetless order.
     /// </summary>
@@ -361,7 +363,7 @@ namespace MacroTools.Extensions
       SetUnitOwner(unit, whichPlayer, changeColor);
       return unit;
     }
-    
+
     /// <summary>
     /// Returns the current owner of the specified unit/
     /// </summary>
@@ -378,7 +380,7 @@ namespace MacroTools.Extensions
       WaygateActivate(waygate, flag);
       return waygate;
     }
-    
+
     /// <summary>
     ///   Sets the Waygate's destination to the target point.
     ///   Blindly assumes that the unit is a Waygate.
@@ -495,7 +497,7 @@ namespace MacroTools.Extensions
         .Pause(false);
 
       var asCapital = CapitalManager.GetFromUnit(whichUnit);
-      if (asCapital == null || asCapital.ProtectorCount == 0) 
+      if (asCapital == null || asCapital.ProtectorCount == 0)
         whichUnit.SetInvulnerable(false);
     }
 
@@ -623,7 +625,7 @@ namespace MacroTools.Extensions
       whichUnit.SetLifePercent(percentageHitpoints);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Multiplities the specified unit's mana by the specified amount.
     /// </summary>
@@ -652,7 +654,7 @@ namespace MacroTools.Extensions
         GetUnitState(whichUnit, UNIT_STATE_MAX_MANA) * MathEx.Max(0, percent) * 0.01f);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Sets the unit's maximum mana.
     /// </summary>
@@ -662,7 +664,7 @@ namespace MacroTools.Extensions
       BlzSetUnitMaxMana(whichUnit, maximumMana);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Sets the unit's current mana.
     /// </summary>
@@ -707,7 +709,7 @@ namespace MacroTools.Extensions
       SetUnitAbilityLevel(whichUnit, abilityTypeId, level);
       return whichUnit;
     }
-    
+
     /// <summary>
     /// Removes an ability from a unit.
     /// </summary>
@@ -802,6 +804,54 @@ namespace MacroTools.Extensions
     {
       return whichUnit.IsType(UNIT_TYPE_RESISTANT) || whichUnit.IsType(UNIT_TYPE_HERO) ||
              (whichUnit.OwningPlayer() == Player(PLAYER_NEUTRAL_AGGRESSIVE) && whichUnit.GetLevel() >= 6);
+    }
+
+    /// <summary>
+    /// Removes All abilities not in the ignore list from a unit
+    /// </summary>
+    /// <param name="whichUnit">The unit to remove abilities from</param>
+    /// <param name="ignoredAbilityId">List of ability Ids to not be removed. </param>
+    /// <returns>A List of abilityids for a given unit.</returns>
+    public static unit RemoveAllAbilities(this unit whichUnit, List<int> ignoredAbilityId)
+    {
+      
+      var abilities = GetUnitAbilities(whichUnit);
+
+      foreach (var ability in abilities)
+      {
+        var abilityid = BlzGetAbilityId(ability);
+        if (!ignoredAbilityId.Contains(abilityid))
+        {
+          RemoveAbility(whichUnit, abilityid);
+        }
+      }
+
+      return whichUnit;
+    }
+    
+    /// <summary>
+    /// Gets all the abilities for a unit
+    /// </summary>
+    /// <param name="whichUnit">The unit to get the abilities of.</param>
+    /// <returns>A List of ability objects for a given unit.</returns>
+    public static List<ability> GetUnitAbilities(this unit whichUnit)
+    {
+      
+      var abilities = new List<ability>();
+      var index = 0;
+
+      while(true)
+      {
+        var ability = BlzGetUnitAbilityByIndex(whichUnit, index);
+
+        if (ability is null)
+          break;
+        
+        abilities.Add(ability);
+        index++;
+      }
+
+      return abilities;
     }
   }
 }

--- a/src/MacroTools/Libraries/GeneralHelpers.cs
+++ b/src/MacroTools/Libraries/GeneralHelpers.cs
@@ -142,5 +142,8 @@ namespace MacroTools.Libraries
       RegionAddRect(rectRegion, whichRect);
       return rectRegion;
     }
+    
+    /// @CSharpLua.Template = "BlzGetAbilityId({0})"
+    public static extern int BlzGetAbilityId(ability whichAbility);
   }
 }

--- a/src/MacroTools/PassiveAbilities/PersistentSoul.cs
+++ b/src/MacroTools/PassiveAbilities/PersistentSoul.cs
@@ -93,8 +93,9 @@ namespace MacroTools.PassiveAbilities
         .SetColor(200, 50, 50, 255)
         .SetExplodeOnDeath(true)
         .AddType(UNIT_TYPE_UNDEAD)
-        .AddType(UNIT_TYPE_SUMMONED);
-       
+        .AddType(UNIT_TYPE_SUMMONED)
+        .RemoveAllAbilities(new List<int>{1096905835,1097690998,1112498531});
+      
       whichUnit.Remove();
       
       reanimatedUnit.SetPosition(whichUnitPosition);

--- a/src/TestMap.Source/Setup/CheatSetup.cs
+++ b/src/TestMap.Source/Setup/CheatSetup.cs
@@ -1,4 +1,5 @@
-﻿using MacroTools.Cheats;
+﻿using System;
+using MacroTools.Cheats;
 using MacroTools.CommandSystem;
 using MacroTools.QuestSystem;
 
@@ -38,6 +39,8 @@ namespace TestMap.Source.Setup
       commandManager.Register(new CheatDestroy());
       commandManager.Register(new CheatGod());
       commandManager.Register(new CheatPosition());
+      commandManager.Register(new CheatGetUnitAbilities());
+      commandManager.Register(new CheatRemoveAllAbilities());
       TestMode.Setup(commandManager);
     }
   }

--- a/src/WarcraftLegacies.Source/Setup/CheatSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/CheatSetup.cs
@@ -42,6 +42,8 @@ namespace WarcraftLegacies.Source.Setup
       commandManager.Register(new CheatVision());
       commandManager.Register(new CheatShore());
       commandManager.Register(new CheatPosition());
+      commandManager.Register(new CheatGetUnitAbilities());
+      commandManager.Register(new CheatRemoveAllAbilities());
       TestMode.Setup(commandManager);
       CheatSkipCinematic.Setup();
     }

--- a/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
@@ -20,7 +20,7 @@ namespace WarcraftLegacies.Source.Setup.Spells
       SpellSystem.Register(new SingleTargetRecall(Constants.ABILITY_A0W8_RECALL_FROZEN_THRONE));
 
       PassiveAbilityManager.Register(new PersistentSoul(Constants.UNIT_N009_REVENANT_SCOURGE,
-        Constants.ABILITY_A05L_PERSISTENT_SOUL_SCOURGE_REVENANT, new List<int>{ Constants.ABILITY_ACRK_RESISTANT_SKIN_1_1_POSITION, Constants.ABILITY_ACSK_RESISTANT_SKIN_2_1_POSITION, Constants.ABILITY_A08P_RESISTANT_SKIN_3_1_POSITION })
+        Constants.ABILITY_A05L_PERSISTENT_SOUL_SCOURGE_REVENANT, new List<int>{ Constants.ABILITY_ACRK_RESISTANT_SKIN_1_1_POSITION, Constants.ABILITY_ACSK_RESISTANT_SKIN_2_1_POSITION, Constants.ABILITY_A08P_RESISTANT_SKIN_3_1_POSITION, Constants.ABILITY_ARSK_RESISTANT_SKIN_BROWN_MOUNTAIN_GIANT })
       {
         ReanimationCountLevel = 1,
         Duration = 40,


### PR DESCRIPTION
Implemented unit extension functions for getting all unit abilities and removing all unit abilities.

Units created with persistent soul now have abilities removed

Added and Exact variable to command so we can set if a command needs to be an exact match. This avoids the '-c' command firing when any other command starts with '-c'

Updated all cheats and commands to have an Exact value

Implemented workaround suggested by [Drake53](https://github.com/Drake53) for War3Api.Common 1.33 not having the BlzGetAbilityId() functionality

These changes solve issue #1497 and #1321