### PR TITLE
Parametrize and shorten cinematic duration

### DIFF
--- a/src/WarcraftLegacies.Source/GameLogic/DalaGilneasChoice.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/DalaGilneasChoice.cs
@@ -24,13 +24,13 @@ namespace WarcraftLegacies.Source.GameLogic
     /// <summary>
     /// Sets up <see cref="DalaGilneasChoiceDialogue"/>.
     /// </summary>
-    public static void Setup()
+    public static void Setup(int introSeconds)
     {
       DialogSetMessage(PickDialogue, "Pick your Faction");
       var timer = CreateTimer();
-      TimerStart(timer, 4, false, StartFactionPick);
+      TimerStart(timer, 2, false, StartFactionPick);
       var concludeTimer = CreateTimer();
-      TimerStart(concludeTimer, 24, false, ConcludeFactionPick);
+      TimerStart(concludeTimer, introSeconds - 12, false, ConcludeFactionPick);
     }
 
     private static void ConcludeFactionPick()

--- a/src/WarcraftLegacies.Source/GameLogic/IllidariSunfuryChoice.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/IllidariSunfuryChoice.cs
@@ -24,13 +24,13 @@ namespace WarcraftLegacies.Source.GameLogic
     /// <summary>
     /// Sets up <see cref="IllidariSunfuryChoiceDialogue"/>.
     /// </summary>
-    public static void Setup()
+    public static void Setup(int introSeconds)
     {
       DialogSetMessage(PickDialogue, "Pick your Faction");
       var timer = CreateTimer();
-      TimerStart(timer, 4, false, StartFactionPick);
+      TimerStart(timer, 2, false, StartFactionPick);
       var concludeTimer = CreateTimer();
-      TimerStart(concludeTimer, 24, false, ConcludeFactionPick);
+      TimerStart(concludeTimer, introSeconds - 12, false, ConcludeFactionPick);
     }
 
     private static void ConcludeFactionPick()

--- a/src/WarcraftLegacies.Source/GameLogic/LegionForsakenChoice.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/LegionForsakenChoice.cs
@@ -24,13 +24,13 @@ namespace WarcraftLegacies.Source.GameLogic
     /// <summary>
     /// Sets up <see cref="LegionForsakenChoiceDialogue"/>.
     /// </summary>
-    public static void Setup()
+    public static void Setup(int introSeconds)
     {
       DialogSetMessage(PickDialogue, "Pick your Faction");
       var timer = CreateTimer();
-      TimerStart(timer, 4, false, StartFactionPick);
+      TimerStart(timer, 2, false, StartFactionPick);
       var concludeTimer = CreateTimer();
-      TimerStart(concludeTimer, 24, false, ConcludeFactionPick);
+      TimerStart(concludeTimer, introSeconds - 12, false, ConcludeFactionPick);
     }
 
     private static void ConcludeFactionPick()

--- a/src/WarcraftLegacies.Source/GameLogic/OpenAllianceVote.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/OpenAllianceVote.cs
@@ -29,13 +29,13 @@ namespace WarcraftLegacies.Source.GameLogic
     /// <summary>
     /// Sets up <see cref="OpenAllianceVote"/>.
     /// </summary>
-    public static void Setup()
+    public static void Setup(int introSeconds)
     {
       DialogSetMessage(VoteDialogue, "Vote Game Mode");
       var timer = CreateTimer();
-      TimerStart(timer, 49, false, StartVote);
+      TimerStart(timer, introSeconds - 11, false, StartVote);
       var concludeTimer = CreateTimer();
-      TimerStart(concludeTimer, 59, false, ConcludeVote);
+      TimerStart(concludeTimer, introSeconds - 1, false, ConcludeVote);
     }
     
     private static void ConcludeVote()

--- a/src/WarcraftLegacies.Source/GameLogic/StartingResources.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/StartingResources.cs
@@ -11,10 +11,10 @@ namespace WarcraftLegacies.Source.GameLogic
     /// <summary>
     /// After a period of time, gives all players their starting resources.
     /// </summary>
-    public static void Setup()
+    public static void Setup(int introSeconds)
     {
       var trig = CreateTrigger();
-      TriggerRegisterTimerEvent(trig, 58, false);
+      TriggerRegisterTimerEvent(trig, introSeconds, false);
       TriggerAddAction(trig, () =>
       {
         foreach (var player in WCSharp.Shared.Util.EnumeratePlayers())

--- a/src/WarcraftLegacies.Source/GameLogic/ZandalarGoblinChoice.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/ZandalarGoblinChoice.cs
@@ -24,13 +24,13 @@ namespace WarcraftLegacies.Source.GameLogic
     /// <summary>
     /// Sets up <see cref="ZandalarGoblinChoiceDialogue"/>.
     /// </summary>
-    public static void Setup()
+    public static void Setup(int introSeconds)
     {
       DialogSetMessage(PickDialogue, "Pick your Faction");
       var timer = CreateTimer();
-      TimerStart(timer, 4, false, StartFactionPick);
+      TimerStart(timer, 2, false, StartFactionPick);
       var concludeTimer = CreateTimer();
-      TimerStart(concludeTimer, 24, false, ConcludeFactionPick);
+      TimerStart(concludeTimer, introSeconds - 12, false, ConcludeFactionPick);
     }
 
     private static void ConcludeFactionPick()

--- a/src/WarcraftLegacies.Source/Setup/GameSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/GameSetup.cs
@@ -29,7 +29,7 @@ namespace WarcraftLegacies.Source.Setup
     /// </summary>
     public static void Setup()
     {
-      var introSeconds = 60;
+      var introSeconds = 30;
       var displayIntroText = new DisplayIntroText((introSeconds / 2) - 5);
       var cinematicMode = new CinematicMode(introSeconds + 2, displayIntroText);
       var gameTime = new GameTime(introSeconds);

--- a/src/WarcraftLegacies.Source/Setup/GameSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/GameSetup.cs
@@ -30,7 +30,7 @@ namespace WarcraftLegacies.Source.Setup
     public static void Setup()
     {
       var introSeconds = 30;
-      var displayIntroText = new DisplayIntroText((introSeconds / 2) - 5);
+      var displayIntroText = new DisplayIntroText(introSeconds - 11);
       var cinematicMode = new CinematicMode(introSeconds + 2, displayIntroText);
       var gameTime = new GameTime(introSeconds);
       SetupControlPointManager();

--- a/src/WarcraftLegacies.Source/Setup/GameSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/GameSetup.cs
@@ -29,9 +29,10 @@ namespace WarcraftLegacies.Source.Setup
     /// </summary>
     public static void Setup()
     {
-      var displayIntroText = new DisplayIntroText(25);
-      var cinematicMode = new CinematicMode(59, displayIntroText);
-      var gameTime = new GameTime();
+      var introSeconds = 60;
+      var displayIntroText = new DisplayIntroText((introSeconds / 2) - 5);
+      var cinematicMode = new CinematicMode(introSeconds + 2, displayIntroText);
+      var gameTime = new GameTime(introSeconds);
       SetupControlPointManager();
       var preplacedUnitSystem = new PreplacedUnitSystem();
       SoundLibrary.Setup();
@@ -45,10 +46,10 @@ namespace WarcraftLegacies.Source.Setup
       AllFactionSetup.Setup(preplacedUnitSystem, artifactSetup);
       SharedFactionConfigSetup.Setup();
       PlayerSetup.Setup();
-      ZandalarGoblinChoiceDialogue.Setup();
-      IllidariSunfuryChoiceDialogue.Setup();
-      DalaGilneasChoiceDialogue.Setup();
-      LegionForsakenChoiceDialogue.Setup();
+      ZandalarGoblinChoiceDialogue.Setup(introSeconds);
+      IllidariSunfuryChoiceDialogue.Setup(introSeconds);
+      DalaGilneasChoiceDialogue.Setup(introSeconds);
+      LegionForsakenChoiceDialogue.Setup(introSeconds);
       NeutralHostileSetup.Setup();
       AllQuestSetup.Setup(preplacedUnitSystem, artifactSetup, allLegendSetup);
       ObserverSetup.Setup(new[] { Player(21) });
@@ -72,7 +73,7 @@ namespace WarcraftLegacies.Source.Setup
       DestructibleSetup.Setup(preplacedUnitSystem);
       ResearchSetup.Setup(preplacedUnitSystem);
       PatronSystem.Setup(preplacedUnitSystem);
-      OpenAllianceVote.Setup();
+      OpenAllianceVote.Setup(introSeconds);
       AugmentSetup.Setup();
       RockSetup.Setup();
       TurnResearchSetup.Setup();
@@ -106,13 +107,13 @@ namespace WarcraftLegacies.Source.Setup
       BlockerSetup.Setup();
       NeutralVictimAndPassiveSetup.Setup();
       GateSetup.Setup();
-      StartingResources.Setup();
-      StartingQuestPopup.Setup(63);
+      StartingResources.Setup(introSeconds - 2);
+      StartingQuestPopup.Setup(introSeconds + 3);
       RefundZeroLimitUnits.Setup();
       HeroGlowFix.Setup();
       CleanPersons.Setup();
       PlayerLeaves.Setup();
-      FloatingTextSetup.Setup(60, 10);
+      FloatingTextSetup.Setup(introSeconds, 10);
       AmbianceSetup.Setup();
       PassiveAbilityManager.InitializePreplacedUnits();
       IncompatibleResearchSetup.Setup();


### PR DESCRIPTION
Hi!

The intro cinematic and subsequent setup events are currently hardcoded with a few constants in dispersed files.

So I propose instead to define the variable `introSeconds` and pass it to the various setup tasks that require it, replacing hard-coded numbers with arithmetic operations so that changing the duration (within reason) still maintains a proper setup.

This would open the possibility to shorten (60 -> 30) the duration of the cinematic, which feels too long, especially in 8v8 when drafting and joining takes time. With a 30 second cinematic, players would have 16 seconds to choose faction (down from 20), and the same to choose mode (10): this removes 25 second of waiting time between faction and mode choice.

Having a variable cinematic duration requires light changes to how the timers are initialized: instead of setting up a timer that ticks every turn duration (60) from the beginning, we set up one timer of `introSeconds` duration (to display "Game starts in:"), at the end of which the turn timer is initialized _and_ one turn is manually triggered.

Tested for durations from 30 to 60 seconds. 
Changing those can be done simply by editing the parameter (see commit "Shorten cinematic intro").

Note: if introSeconds = 60, nothing changes.