### PR TITLE
Defeat unpicked Faction alternatives instead of manually failing their quests

### DIFF
--- a/src/MacroTools/Cheats/CheatKick.cs
+++ b/src/MacroTools/Cheats/CheatKick.cs
@@ -34,7 +34,8 @@ namespace MacroTools.Cheats
         var faction = FactionManager.GetFromName(parameters[0]);
         if (faction == null)
           return $"There is no registered {nameof(Faction)} with the name {parameters[0]}.";
-        faction.ScoreStatus = ScoreStatus.Defeated;
+        
+        faction.Defeat();
         return $"Kicking {nameof(Faction)} {faction.Name}.";
       }
       catch (Exception ex)

--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -59,7 +59,6 @@ namespace MacroTools.FactionSystem
     private string _icon;
     private string _name;
     private player? _player;
-    private ScoreStatus _scoreStatus = ScoreStatus.Undefeated;
     private int _undefeatedResearch;
     private int _xp; //Stored by DistributeUnits and given out again by DistributeResources
 
@@ -164,34 +163,10 @@ namespace MacroTools.FactionSystem
     /// </summary>
     public string CinematicMusic { get; init; }
 
-    public ScoreStatus ScoreStatus
-    {
-      get => _scoreStatus;
-      set
-      {
-        //Change defeated/undefeated researches
-        foreach (var player in WCSharp.Shared.Util.EnumeratePlayers())
-          if (value == ScoreStatus.Defeated)
-          {
-            SetPlayerTechResearched(player, _defeatedResearch, 1);
-            SetPlayerTechResearched(player, _undefeatedResearch, 0);
-          }
-
-        //Remove player from game if necessary
-        if (value == ScoreStatus.Defeated && Player != null)
-        {
-          FogModifierStart(CreateFogModifierRect(Player, FOG_OF_WAR_VISIBLE,
-            WCSharp.Shared.Data.Rectangle.WorldBounds.Rect, false, false));
-          RemovePlayer(Player, PLAYER_GAME_RESULT_DEFEAT);
-          SetPlayerState(Player, PLAYER_STATE_OBSERVER, 1);
-          Leave();
-        }
-
-        _scoreStatus = value;
-        StatusChanged?.Invoke(this, this);
-        ScoreStatusChanged?.Invoke(this, this);
-      }
-    }
+    /// <summary>
+    /// Whether or not the <see cref="Faction"/> has been defeated.
+    /// </summary>
+    public ScoreStatus ScoreStatus { get; private set; } = ScoreStatus.Undefeated;
 
     public string ColoredName => PrefixCol + _name + "|r";
 
@@ -339,6 +314,31 @@ namespace MacroTools.FactionSystem
     /// </summary>
     public event EventHandler<Faction>? StatusChanged;
 
+    /// <summary>
+    /// Defeats the player, making them an observer, and distributing their units and resources to allies if possible.
+    /// </summary>
+    public void Defeat()
+    {
+      foreach (var player in WCSharp.Shared.Util.EnumeratePlayers())
+      {
+        SetPlayerTechResearched(player, _defeatedResearch, 1);
+        SetPlayerTechResearched(player, _undefeatedResearch, 0);
+      }
+      
+      if (Player != null)
+      {
+        FogModifierStart(CreateFogModifierRect(Player, FOG_OF_WAR_VISIBLE,
+          WCSharp.Shared.Data.Rectangle.WorldBounds.Rect, false, false));
+        RemovePlayer(Player, PLAYER_GAME_RESULT_DEFEAT);
+        SetPlayerState(Player, PLAYER_STATE_OBSERVER, 1);
+        Leave();
+      }
+
+      ScoreStatus = ScoreStatus.Defeated;
+      StatusChanged?.Invoke(this, this);
+      ScoreStatusChanged?.Invoke(this, this);
+    }
+    
     /// <summary>
     ///   Returns all unit types which this <see cref="Faction" /> can only train a limited number of.
     /// </summary>

--- a/src/MacroTools/GameTime.cs
+++ b/src/MacroTools/GameTime.cs
@@ -75,10 +75,7 @@ namespace MacroTools
           if (meetEliminationThreshold)
           {
             if (PlayerData.ByHandle(player).EliminationTurns >= 3)
-            {
-              if (faction != null)
-                faction.ScoreStatus = ScoreStatus.Defeated;
-            }
+              faction?.Defeat();
             else
             {
               DisplayTextToPlayer(player, 0, 0,

--- a/src/MacroTools/QuestSystem/QuestData.cs
+++ b/src/MacroTools/QuestSystem/QuestData.cs
@@ -43,12 +43,6 @@ namespace MacroTools.QuestSystem
       set => QuestSetRequired(Quest, value);
     }
 
-
-    /// <summary>
-    /// Indicates that multiple players have this quest. Setting this does not actually cause the quest to be shared.
-    /// </summary>
-    public bool Shared { get; set; }
-
     /// <summary>
     /// A user-friendly name for the quest.
     /// </summary>

--- a/src/WarcraftLegacies.Source/Commands/ObserverCommand.cs
+++ b/src/WarcraftLegacies.Source/Commands/ObserverCommand.cs
@@ -35,7 +35,7 @@ namespace WarcraftLegacies.Source.Commands
           $"{GetPlayerName(GetTriggerPlayer())} tried to execute {nameof(ObserverCommand)}, but they don't have a {nameof(Faction)}.");
       }
       
-      triggerFaction.ScoreStatus = ScoreStatus.Defeated;
+      triggerFaction.Defeat();
       triggerFaction.Player?.SetTeam(_observers!);
     }
   }

--- a/src/WarcraftLegacies.Source/GameLogic/CleanPersons.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/CleanPersons.cs
@@ -27,7 +27,7 @@ namespace WarcraftLegacies.Source.GameLogic
           if (playerFaction == null) continue;
           if (GetPlayerSlotState(player) != PLAYER_SLOT_STATE_PLAYING &&
               playerFaction.ScoreStatus == ScoreStatus.Undefeated)
-            playerFaction.ScoreStatus = ScoreStatus.Defeated;
+            playerFaction.Defeat();
         }
       });
     }

--- a/src/WarcraftLegacies.Source/GameLogic/DalaGilneasChoice.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/DalaGilneasChoice.cs
@@ -96,13 +96,9 @@ namespace WarcraftLegacies.Source.GameLogic
           unit.SetOwner(Player(PLAYER_NEUTRAL_AGGRESSIVE));
         }
         else
-        {
           unit.Remove();
-        }
-        foreach (var quest in faction.GetAllQuests().Where(q => q.Shared is false))
-        {
-          quest.Progress = MacroTools.QuestSystem.QuestProgress.Failed;
-        }
+
+        faction.Defeat();
       }
     }
 

--- a/src/WarcraftLegacies.Source/GameLogic/GameEnd/PlayerLeaves.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/GameEnd/PlayerLeaves.cs
@@ -23,7 +23,7 @@ namespace WarcraftLegacies.Source.GameLogic.GameEnd
             : $"{GetPlayerName(triggerPlayer)} has left the game.");
 
         if (playerFaction != null && playerFaction.ScoreStatus != ScoreStatus.Defeated)
-          playerFaction.ScoreStatus = ScoreStatus.Defeated;
+          playerFaction.Defeat();
       }
       catch (Exception ex)
       {

--- a/src/WarcraftLegacies.Source/GameLogic/IllidariSunfuryChoice.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/IllidariSunfuryChoice.cs
@@ -96,13 +96,9 @@ namespace WarcraftLegacies.Source.GameLogic
           unit.SetOwner(Player(PLAYER_NEUTRAL_AGGRESSIVE));
         }
         else
-        {
           unit.Remove();
-        }
-        foreach (var quest in faction.GetAllQuests().Where(q => q.Shared is false))
-        {
-          quest.Progress = MacroTools.QuestSystem.QuestProgress.Failed;
-        }
+
+        faction.Defeat();
       }
     }
 

--- a/src/WarcraftLegacies.Source/GameLogic/LegionForsakenChoice.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/LegionForsakenChoice.cs
@@ -99,10 +99,8 @@ namespace WarcraftLegacies.Source.GameLogic
         {
           unit.Remove();
         }
-        foreach (var quest in faction.GetAllQuests().Where(q => q.Shared is false))
-        {
-          quest.Progress = MacroTools.QuestSystem.QuestProgress.Failed;
-        }
+
+        faction.Defeat();
       }
     }
 

--- a/src/WarcraftLegacies.Source/GameLogic/ZandalarGoblinChoice.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/ZandalarGoblinChoice.cs
@@ -96,13 +96,9 @@ namespace WarcraftLegacies.Source.GameLogic
           unit.SetOwner(Player(PLAYER_NEUTRAL_AGGRESSIVE));
         }
         else
-        {
           unit.Remove();
-        }
-        foreach (var quest in faction.GetAllQuests().Where(q => q.Shared is false))
-        {
-          quest.Progress = MacroTools.QuestSystem.QuestProgress.Failed;
-        }
+
+        faction.Defeat();
       }
     }
 

--- a/src/WarcraftLegacies.Source/Quests/QuestBookOfMedivh.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestBookOfMedivh.cs
@@ -45,7 +45,6 @@ namespace WarcraftLegacies.Source.Quests
         AddObjective(new ObjectiveCapitalDead(dalaran));
       _bookOfMedivhPedestal = bookOfMedivhPedestal;
       Required = bypassLevelRequirement;
-      Shared = true;
     }
 
     /// <inheritdoc/>

--- a/src/WarcraftLegacies.Source/Quests/QuestDragonsOfNightmare.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestDragonsOfNightmare.cs
@@ -57,7 +57,6 @@ namespace WarcraftLegacies.Source.Quests
       AddObjective(new ObjectiveKillUnit(nightmareDragonEk));
       AddObjective(new ObjectiveTime(360));
       _timer = CreateTimer().Start(360, false, OnTimeElapsed);
-      Shared = true;
     }
 
     private void OnTimeElapsed()

--- a/src/WarcraftLegacies.Source/Quests/QuestNavigation.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestNavigation.cs
@@ -19,7 +19,6 @@ namespace WarcraftLegacies.Source.Quests
       @"ReplaceableTextures\CommandButtons\BTNHumanTransport.blp")
     {
       AddObjective(new ObjectiveTime(780));
-      Shared = true;
       ResearchId = Constants.UPGRADE_R068_QUEST_COMPLETED_NAVIGATION;
     }
 

--- a/src/WarcraftLegacies.Source/Quests/QuestRagnaros.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestRagnaros.cs
@@ -35,7 +35,6 @@ namespace WarcraftLegacies.Source.Quests
         new ObjectiveHeroWithLevelInRect(10, Regions.RagnarosSummon, "the Portal to the Firelands");
       AddObjective(_heroInRectObjective);
       PlayerUnitEvents.Register(UnitEvent.SpellEffect, OnCastSummonSpell, _ragnarosSummoningPedestal);
-      Shared = true;
     }
 
     /// <inheritdoc/>

--- a/src/WarcraftLegacies.Source/Quests/QuestTombOfSargeras.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestTombOfSargeras.cs
@@ -43,7 +43,6 @@ namespace WarcraftLegacies.Source.Quests
       _preventAccessTriggers = CreatePreventAccessTriggers(interiorRects);
       HideUnitsInsideTomb(interiorRects);
       _entranceDoor = entranceDoor.SetInvulnerable(true);
-      Shared = true;
     }
 
     /// <inheritdoc />

--- a/src/WarcraftLegacies.Source/Quests/QuestZinrokhAssembly.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestZinrokhAssembly.cs
@@ -24,7 +24,6 @@ namespace WarcraftLegacies.Source.Quests
       _fragments = fragments;
       foreach (var artifact in fragments) 
         AddObjective(new ObjectiveAcquireArtifact(artifact));
-      Shared = true;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Previously, when a Faction was not picked after some time, we would go through all of their quests and manually fail them. This meant that we had to introduce the Shared property to indicate quests which should not be failed in this way. This wasn't in line with how we typically handle quest failure; quests should generally be responsible for failing themselves. If a quest should fail when the Faction is defeated, it should just use the `ObjectiveSelfExists` Objective. So I have made these changes:
* Create a new `Defeat` method replacing the old `ScoreStatus` setter
* Removed the Shared property from `QuestData`
* When a Faction is not picked, call `Defeat` on it