### PR TITLE
Simplify Persistent Soul by using the UNIT_TYPE_RESISTANT unit type

### DIFF
--- a/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
@@ -2,7 +2,6 @@
 using MacroTools.PassiveAbilitySystem;
 using MacroTools.Spells;
 using MacroTools.SpellSystem;
-using System.Collections.Generic;
 using WarcraftLegacies.Source.Mechanics.Scourge;
 
 namespace WarcraftLegacies.Source.Setup.Spells
@@ -20,7 +19,7 @@ namespace WarcraftLegacies.Source.Setup.Spells
       SpellSystem.Register(new SingleTargetRecall(Constants.ABILITY_A0W8_RECALL_FROZEN_THRONE));
 
       PassiveAbilityManager.Register(new PersistentSoul(Constants.UNIT_N009_REVENANT_SCOURGE,
-        Constants.ABILITY_A05L_PERSISTENT_SOUL_SCOURGE_REVENANT, new List<int>{ Constants.ABILITY_ACRK_RESISTANT_SKIN_1_1_POSITION, Constants.ABILITY_ACSK_RESISTANT_SKIN_2_1_POSITION, Constants.ABILITY_A08P_RESISTANT_SKIN_3_1_POSITION, Constants.ABILITY_ARSK_RESISTANT_SKIN_BROWN_MOUNTAIN_GIANT })
+        Constants.ABILITY_A05L_PERSISTENT_SOUL_SCOURGE_REVENANT)
       {
         ReanimationCountLevel = 1,
         Duration = 40,
@@ -28,8 +27,7 @@ namespace WarcraftLegacies.Source.Setup.Spells
         Radius = 700
       });
       Plagueling.Setup(); //Todo: convert this into being a proper passive ability
-
-
+      
       var massUnholyFrenzy = new MassAnySpell(Constants.ABILITY_A02W_MASS_UNHOLY_FRENZY_SCOURGE)
       {
         DummyAbilityId = Constants.ABILITY_ACUF_UNHOLY_FRENZY_DUMMY,


### PR DESCRIPTION
At some point Persistent Soul was modified to only work on Resistant units. That's probably a good idea, but there's no need to keep a record of Resistant Skin abilities - the engine provides that information for us.