### PR TITLE
Reworked and fixed Eye of the Lich King

### DIFF
--- a/src/WarcraftLegacies.Source/Powers/PingPower.cs
+++ b/src/WarcraftLegacies.Source/Powers/PingPower.cs
@@ -108,7 +108,6 @@ namespace WarcraftLegacies.Source.Powers
     private bool WasTargetHeroUnloaded()
     {
       var issuedOrderName = OrderId2String(GetIssuedOrderId());
-      Console.WriteLine(issuedOrderName);
       return issuedOrderName == "unloadall" ||
              (issuedOrderName == "unload" && GetOrderTargetUnit() == _targetHero.Unit);
     }

--- a/src/WarcraftLegacies.Source/Powers/PingPower.cs
+++ b/src/WarcraftLegacies.Source/Powers/PingPower.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using MacroTools.Extensions;
+﻿using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.LegendSystem;
 using static War3Api.Common;

--- a/src/WarcraftLegacies.Source/Quests/Scourge/QuestCorruptArthas.cs
+++ b/src/WarcraftLegacies.Source/Quests/Scourge/QuestCorruptArthas.cs
@@ -6,9 +6,7 @@ using MacroTools.ObjectiveSystem.Objectives.LegendBased;
 using MacroTools.ObjectiveSystem.Objectives.MetaBased;
 using MacroTools.ObjectiveSystem.Objectives.QuestBased;
 using MacroTools.QuestSystem;
-using WarcraftLegacies.Source.Powers;
 using WarcraftLegacies.Source.Setup.FactionSetup;
-using WCSharp.Shared.Data;
 using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Quests.Scourge
@@ -54,49 +52,6 @@ namespace WarcraftLegacies.Source.Quests.Scourge
           .Remove();
         completingFaction.RemovePowerByName("Eye of the Lich King");
       }
-    }
-  }
-
-  /// <summary>
-  /// 
-  /// </summary>
-  public sealed class QuestDestroyStratholme : QuestData
-  {
-    private readonly LegendaryHero _arthas;
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="stratholme"></param>
-    /// <param name="arthas"></param>
-    public QuestDestroyStratholme(Capital stratholme, LegendaryHero arthas) : base("The Culling", "When the city of Stratholme falls, Prince Arthas' despair will make him more susceptible to the power of the Lich King.", "ReplaceableTextures\\CommandButtons\\BTNRuneblade.blp")
-    {
-      _arthas = arthas;
-      AddObjective(new ObjectiveCapitalDead(stratholme));
-      Required = true;
-    }
-
-    private bool IsPointValidForArthas(Point whichPoint) =>
-      !whichPoint.IsPathable(PATHING_TYPE_FLOATABILITY) && whichPoint.IsPathable(PATHING_TYPE_WALKABILITY);
-
-    /// <inheritdoc />
-    protected override string RewardFlavour => "Prince Arthas could not protect the people of Stratholme. The Lich King's hold over him grows stronger.";
-
-    /// <inheritdoc />
-    protected override string RewardDescription => $"You gain the power Eye of the Lich King.";
-
-    /// <inheritdoc />
-    protected override void OnComplete(Faction completingFaction)
-    {
-      completingFaction.AddPower(new PingPower(_arthas, "Eye of the Lich King", 5, 60));
-
-      Point randomPoint;
-      do
-      {
-        randomPoint = Regions.ArthasRandomPoint.GetRandomPoint();
-      } while (!IsPointValidForArthas(randomPoint));
-
-      ReviveHero(_arthas.Unit, randomPoint.X, randomPoint.Y, true);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Scourge/QuestDestroyStratholme.cs
+++ b/src/WarcraftLegacies.Source/Quests/Scourge/QuestDestroyStratholme.cs
@@ -1,0 +1,47 @@
+﻿using MacroTools.Extensions;
+using MacroTools.FactionSystem;
+using MacroTools.LegendSystem;
+using MacroTools.ObjectiveSystem.Objectives.LegendBased;
+using MacroTools.QuestSystem;
+using static War3Api.Common;
+using WarcraftLegacies.Source.Powers;
+using WarcraftLegacies.Source.Setup.FactionSetup;
+using WCSharp.Shared.Data;
+
+namespace WarcraftLegacies.Source.Quests.Scourge
+{
+  public sealed class QuestDestroyStratholme : QuestData
+  {
+    private readonly LegendaryHero _arthas;
+    
+    public QuestDestroyStratholme(Capital stratholme, LegendaryHero arthas) : base("The Culling", "When the city of Stratholme falls, Prince Arthas' despair will make him more susceptible to the power of the Lich King.", "ReplaceableTextures\\CommandButtons\\BTNRuneblade.blp")
+    {
+      _arthas = arthas;
+      AddObjective(new ObjectiveCapitalDead(stratholme));
+      Required = true;
+    }
+
+    private static bool IsPointValidForArthas(Point whichPoint) =>
+      !whichPoint.IsPathable(PATHING_TYPE_FLOATABILITY) && whichPoint.IsPathable(PATHING_TYPE_WALKABILITY);
+
+    /// <inheritdoc />
+    protected override string RewardFlavour => "Prince Arthas could not protect the people of Stratholme. The Lich King's hold over him grows stronger.";
+
+    /// <inheritdoc />
+    protected override string RewardDescription => "Gain the power Eye of the Lich King, which allows you to identify where Arthas is at any time";
+
+    /// <inheritdoc />
+    protected override void OnComplete(Faction completingFaction)
+    {
+      Point randomPoint;
+      do
+      {
+        randomPoint = Regions.ArthasRandomPoint.GetRandomPoint();
+      } while (!IsPointValidForArthas(randomPoint));
+
+      _arthas.ForceCreate(LordaeronSetup.Lordaeron?.Player ?? Player(PLAYER_NEUTRAL_AGGRESSIVE), randomPoint, 270);
+      
+      completingFaction.AddPower(new PingPower(_arthas, "Eye of the Lich King", 5, 5));
+    }
+  }
+}


### PR DESCRIPTION
* Eye of the Lich King works even when Arthas is in a transport
* Eye of the Lich King no longer pings when it's first acquired
* QuestDestroyStratholme forcibly spawns Arthas if he has not been trained
* Reduced cooldown of Eye of the Scourge from 60 seconds to 5
* Separated QuestDestroyStratholme into its own file