### PR TITLE
Reduce the control point level requirement of "Secrets of Uldum" from 15 to 5

### DIFF
--- a/src/WarcraftLegacies.Source/Quests/Ironforge/QuestExpedition.cs
+++ b/src/WarcraftLegacies.Source/Quests/Ironforge/QuestExpedition.cs
@@ -31,7 +31,7 @@ namespace WarcraftLegacies.Source.Quests.Ironforge
       @"ReplaceableTextures\CommandButtons\BTNGatherGold.blp")
     {
       _rewardArtifactItemTypeId = rewardArtifactItemTypeId;
-      AddObjective(new ObjectiveControlLevel(ControlPointManager.Instance.GetFromUnitType(Constants.UNIT_N0BD_ULDUM_10GOLD_MIN), 15));
+      AddObjective(new ObjectiveControlLevel(ControlPointManager.Instance.GetFromUnitType(Constants.UNIT_N0BD_ULDUM_10GOLD_MIN), 5));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Secrets of Uldum is an amusing quest concept, but it seems to rarely get completed due to how far away it is and the reward tending not to be that impressive. This just makes it more accessible.