### PR TITLE
Do not store unit heights in map data when converting from W3X to MapData

### DIFF
--- a/src/Launcher/DataTransferObjects/UnitDataDto.cs
+++ b/src/Launcher/DataTransferObjects/UnitDataDto.cs
@@ -23,7 +23,7 @@ namespace Launcher.DataTransferObjects
     public int WaygateDestinationRegionId { get; set; }
     public int TypeId { get; set; }
     public int Variation { get; set; }
-    public Vector3Dto Position { get; set; }
+    public Vector2Dto Position { get; set; }
     public double Rotation { get; set; }
     public Vector3Dto Scale { get; set; }
     public int SkinId { get; set; }

--- a/src/Launcher/Services/AutoMapperConfigurationProvider.cs
+++ b/src/Launcher/Services/AutoMapperConfigurationProvider.cs
@@ -42,7 +42,9 @@ namespace Launcher.Services
         cfg.CreateMap<PlayerDataDto, PlayerData>().ReverseMap();
         cfg.CreateMap<TerrainTileDto, TerrainTile>().ReverseMap();
         cfg.CreateMap<UnitData, UnitDataDto>().ForMember(dest => dest.Position, opt 
-          => opt.MapFrom<UnitDataZPositionValueResolver>()).ReverseMap();
+          => opt.MapFrom<UnitDataDtoZPositionValueResolver>());
+        cfg.CreateMap<UnitDataDto, UnitData>().ForMember(dest => dest.Position, opt 
+          => opt.MapFrom<UnitDataZPositionValueResolver>());
         cfg.CreateMap<DoodadDataDto, DoodadData>().ReverseMap();
         cfg.CreateMap<Vector3Dto, Vector3>().ReverseMap();
         cfg.CreateMap<Vector2Dto, Vector2>().ReverseMap();

--- a/src/Launcher/Services/AutoMapperConfigurationProvider.cs
+++ b/src/Launcher/Services/AutoMapperConfigurationProvider.cs
@@ -41,7 +41,8 @@ namespace Launcher.Services
         cfg.CreateMap<SoundDto, Sound>().ReverseMap();
         cfg.CreateMap<PlayerDataDto, PlayerData>().ReverseMap();
         cfg.CreateMap<TerrainTileDto, TerrainTile>().ReverseMap();
-        cfg.CreateMap<UnitDataDto, UnitData>().ReverseMap();
+        cfg.CreateMap<UnitData, UnitDataDto>().ForMember(dest => dest.Position, opt 
+          => opt.MapFrom<UnitDataZPositionValueResolver>()).ReverseMap();
         cfg.CreateMap<DoodadDataDto, DoodadData>().ReverseMap();
         cfg.CreateMap<Vector3Dto, Vector3>().ReverseMap();
         cfg.CreateMap<Vector2Dto, Vector2>().ReverseMap();

--- a/src/Launcher/ValueResolvers/UnitDataDtoZPositionValueResolver.cs
+++ b/src/Launcher/ValueResolvers/UnitDataDtoZPositionValueResolver.cs
@@ -1,5 +1,4 @@
-﻿using System.Numerics;
-using AutoMapper;
+﻿using AutoMapper;
 using Launcher.DataTransferObjects;
 using War3Net.Build.Widget;
 
@@ -9,12 +8,12 @@ namespace Launcher.ValueResolvers
   /// MapData stores Unit positions without their height, since that can be recalculated from their position
   /// on the terrain.
   /// </summary>
-  public sealed class UnitDataZPositionValueResolver : IValueResolver<UnitDataDto, UnitData, Vector3>
+  public sealed class UnitDataDtoZPositionValueResolver : IValueResolver<UnitData, UnitDataDto, Vector2Dto>
   {
     /// <inheritdoc />
-    public Vector3 Resolve(UnitDataDto source, UnitData destination, Vector3 destMember, ResolutionContext context)
+    public Vector2Dto Resolve(UnitData source, UnitDataDto destination, Vector2Dto destMember, ResolutionContext context)
     {
-      return new Vector3
+      return new Vector2Dto
       {
         X = source.Position.X,
         Y = source.Position.Y

--- a/src/Launcher/ValueResolvers/UnitDataZPositionValueResolver.cs
+++ b/src/Launcher/ValueResolvers/UnitDataZPositionValueResolver.cs
@@ -1,0 +1,23 @@
+﻿using AutoMapper;
+using Launcher.DataTransferObjects;
+using War3Net.Build.Widget;
+
+namespace Launcher.ValueResolvers
+{
+  /// <summary>
+  /// MapData stores Unit positions without their height, since that can be recalculated from their position
+  /// on the terrain.
+  /// </summary>
+  public sealed class UnitDataZPositionValueResolver : IValueResolver<UnitData, UnitDataDto, Vector2Dto>
+  {
+    /// <inheritdoc />
+    public Vector2Dto Resolve(UnitData source, UnitDataDto destination, Vector2Dto destMember, ResolutionContext context)
+    {
+      return new Vector2Dto
+      {
+        X = source.Position.X,
+        Y = source.Position.Y
+      };
+    }
+  }
+}


### PR DESCRIPTION
Heights are ultimately unneeded as the game can simply recalculate them.