### PR TITLE
Capitals and gates gain a percentage of their base hit points every turn

### DIFF
--- a/src/MacroTools/Cheats/CheatSkipTurns.cs
+++ b/src/MacroTools/Cheats/CheatSkipTurns.cs
@@ -1,0 +1,33 @@
+﻿using MacroTools.CommandSystem;
+using static War3Api.Common;
+
+namespace MacroTools.Cheats
+{
+  public sealed class CheatSkipTurns : Command
+  {
+    /// <inheritdoc />
+    public override string CommandText => "skipturns";
+
+    /// <inheritdoc />
+    public override bool Exact => false;
+
+    /// <inheritdoc />
+    public override int MinimumParameterCount => 1;
+
+    /// <inheritdoc />
+    public override CommandType Type => CommandType.Cheat;
+
+    /// <inheritdoc />
+    public override string Description => "Skips the game forward a number of turns.";
+
+    /// <inheritdoc />
+    public override string Execute(player cheater, params string[] parameters)
+    {
+      if (!int.TryParse(parameters[0], out var turnSkip))
+        return "You must specify a whole number as the first parameter.";
+
+      GameTime.SkipTurns(turnSkip);
+      return $"Skipping forward {turnSkip} turns.";
+    }
+  }
+}

--- a/src/MacroTools/Cheats/CheatSkipTurns.cs
+++ b/src/MacroTools/Cheats/CheatSkipTurns.cs
@@ -12,7 +12,7 @@ namespace MacroTools.Cheats
     public override bool Exact => false;
 
     /// <inheritdoc />
-    public override int MinimumParameterCount => 1;
+    public override int MinimumParameterCount => 0;
 
     /// <inheritdoc />
     public override CommandType Type => CommandType.Cheat;

--- a/src/MacroTools/GameTime.cs
+++ b/src/MacroTools/GameTime.cs
@@ -53,15 +53,14 @@ namespace MacroTools
     public static void SkipTurns(int turnSkip)
     {
       _currentTime += TurnDuration*turnSkip;
-      _turnCount += turnSkip;
       for (var i = 0; i < turnSkip; i++)
-        TurnEnded?.Invoke(null, EventArgs.Empty);
+        EndTurn();
     }
     
     private static void EndTurn()
     {
       _turnCount += 1;
-      TimerDialogSetTitle(_turnTimerDialog, $"Turn {I2S(_turnCount)}");
+      TimerDialogSetTitle(_turnTimerDialog, $"Turn {_turnCount}");
       if (_turnCount >= 20)
       {
         foreach (var player in WCSharp.Shared.Util.EnumeratePlayers(PLAYER_SLOT_STATE_PLAYING, MAP_CONTROL_USER))

--- a/src/MacroTools/GameTime.cs
+++ b/src/MacroTools/GameTime.cs
@@ -49,6 +49,15 @@ namespace MacroTools
     /// <returns>The number of seconds that have elapsed since the start of the game</returns>
     public static float GetGameTime() => _currentTime;
 
+    /// <summary>Skips the game forward a number of turns.</summary>
+    public static void SkipTurns(int turnSkip)
+    {
+      _currentTime += TurnDuration*turnSkip;
+      _turnCount += turnSkip;
+      for (var i = 0; i < turnSkip; i++)
+        TurnEnded?.Invoke(null, EventArgs.Empty);
+    }
+    
     private static void EndTurn()
     {
       _turnCount += 1;

--- a/src/MacroTools/GameTime.cs
+++ b/src/MacroTools/GameTime.cs
@@ -43,6 +43,9 @@ namespace MacroTools
 
     public static int ConvertGameTimeToTurn(float gameTime) => (int)Math.Floor(gameTime / TurnDuration);
 
+    /// <summary>What turn it is right now.</summary>
+    public static int GetTurn() => ConvertGameTimeToTurn(_currentTime);
+    
     /// <returns>The number of seconds that have elapsed since the start of the game</returns>
     public static float GetGameTime() => _currentTime;
 

--- a/src/MacroTools/LegendSystem/Capital.cs
+++ b/src/MacroTools/LegendSystem/Capital.cs
@@ -20,11 +20,6 @@ namespace MacroTools.LegendSystem
     /// </summary>
     public int ProtectorCount => _protectors.Count;
     
-    /// <summary>
-    /// Get list of <see cref="Protector"/>s
-    /// </summary>
-    public List<Protector> Protectors => _protectors;
-    
     public readonly Dictionary<unit, Protector> ProtectorsByUnit = new();
 
     /// <summary>

--- a/src/MacroTools/LegendSystem/CapitalManager.cs
+++ b/src/MacroTools/LegendSystem/CapitalManager.cs
@@ -24,6 +24,7 @@ namespace MacroTools.LegendSystem
         throw new Exception($"Tried to register {nameof(Capital)} {capital.Name} but it is already registered.");
       ByUnit.Add(capital.Unit, capital);
       AllCapitals.Add(capital);
+      TurnBasedHitpointsManager.Register(capital.Unit);
     }
 
     /// <summary>
@@ -51,14 +52,6 @@ namespace MacroTools.LegendSystem
           return true;
       }
       return false;
-    }
-    
-    /// <summary>
-    ///   Whether or not the given unit is a <see cref="Protector" /> of a given <see cref="Capital" />.
-    /// </summary>
-    public static bool UnitIsCapitalProtector(unit protector, unit capital)
-    {
-      return ByUnit[capital].ProtectorsByUnit.ContainsKey(protector);
     }
     
     /// <summary>

--- a/src/MacroTools/LegendSystem/CapitalManager.cs
+++ b/src/MacroTools/LegendSystem/CapitalManager.cs
@@ -13,6 +13,9 @@ namespace MacroTools.LegendSystem
     private static readonly Dictionary<unit, Capital> ByUnit = new();
     private static readonly List<Capital> AllCapitals = new();
 
+    /// <summary>Capitals will gain this many hit points, as a percentage of their maximum, per turn.</summary>
+    public const float HitPointPercentagePerTurn = 0.1f;
+    
     /// <summary>
     /// Registers a <see cref="Capital"/> to the <see cref="CapitalManager"/>.
     /// </summary>
@@ -24,7 +27,7 @@ namespace MacroTools.LegendSystem
         throw new Exception($"Tried to register {nameof(Capital)} {capital.Name} but it is already registered.");
       ByUnit.Add(capital.Unit, capital);
       AllCapitals.Add(capital);
-      TurnBasedHitpointsManager.Register(capital.Unit);
+      TurnBasedHitpointsManager.Register(capital.Unit, HitPointPercentagePerTurn);
     }
 
     /// <summary>

--- a/src/MacroTools/PassiveAbilities/Gate.cs
+++ b/src/MacroTools/PassiveAbilities/Gate.cs
@@ -47,6 +47,7 @@ namespace MacroTools.PassiveAbilities
     {
       if (createdUnit.GetTypeId() == _openedId) 
         createdUnit.SetAnimation("death alternate");
+      TurnBasedHitpointsManager.Register(createdUnit);
     }
 
     /// <inheritdoc />

--- a/src/MacroTools/PassiveAbilities/Gate.cs
+++ b/src/MacroTools/PassiveAbilities/Gate.cs
@@ -9,6 +9,9 @@ namespace MacroTools.PassiveAbilities
   /// </summary>
   public sealed class Gate : PassiveAbility
   {
+    /// <summary>Gates will gain this many hit points, as a percentage of their maximum, per turn.</summary>
+    public const float HitPointPercentagePerTurn = 0.1f;
+    
     private readonly int _openedId;
     private readonly int _deadId;
     
@@ -47,7 +50,7 @@ namespace MacroTools.PassiveAbilities
     {
       if (createdUnit.GetTypeId() == _openedId) 
         createdUnit.SetAnimation("death alternate");
-      TurnBasedHitpointsManager.Register(createdUnit);
+      TurnBasedHitpointsManager.Register(createdUnit, HitPointPercentagePerTurn);
     }
 
     /// <inheritdoc />

--- a/src/MacroTools/TurnBasedHitpointsManager.cs
+++ b/src/MacroTools/TurnBasedHitpointsManager.cs
@@ -34,7 +34,7 @@ namespace MacroTools
       foreach (var (unit, baseHitPoints) in UnitBaseHitPoints)
       {
         var bonusPercentage = HitPointPercentagePerTurn * turn;
-        unit.SetMaximumHitpoints((int)(1 + baseHitPoints * (1 + bonusPercentage)));
+        unit.SetMaximumHitpoints((int)(baseHitPoints * (1 + bonusPercentage)));
         unit.SetCurrentHitpoints(unit.GetMaximumHitPoints());
       }
       

--- a/src/MacroTools/TurnBasedHitpointsManager.cs
+++ b/src/MacroTools/TurnBasedHitpointsManager.cs
@@ -8,19 +8,20 @@ namespace MacroTools
   /// <summary>A tool for giving units additional hit points per turn.</summary>
   public static class TurnBasedHitpointsManager
   {
-    /// <summary>Registered units will gain this many hit points, as a percentage of their maximum, per turn.</summary>
-    public const float HitPointPercentagePerTurn = 0.1f;
-
     /// <summary>Past this turn, units will not gain maximum hit points.</summary>
     private const float TurnLimit = 60;
 
-    private static readonly Dictionary<unit, int> UnitBaseHitPoints = new();
+    private static readonly Dictionary<unit, TurnBasedHitpointData> UnitBaseHitPoints = new();
     private static bool _intialized;
     
     /// <summary>Causes the unit to continously gain maximum hit points as each turn passes.</summary>
-    public static void Register(unit whichUnit)
+    public static void Register(unit whichUnit, float hitPointPercentagePerTurn)
     {
-      UnitBaseHitPoints.Add(whichUnit, whichUnit.GetMaximumHitPoints());
+      UnitBaseHitPoints.Add(whichUnit, new TurnBasedHitpointData
+      {
+        HitPointPercentagePerTurn = hitPointPercentagePerTurn,
+        BaseHitPoints = whichUnit.GetMaximumHitPoints()
+      });
       if (_intialized) 
         return;
       
@@ -31,15 +32,21 @@ namespace MacroTools
     private static void OnTurnEnded(object? sender, EventArgs eventArgs)
     {
       var turn = GameTime.GetTurn();
-      foreach (var (unit, baseHitPoints) in UnitBaseHitPoints)
+      foreach (var (unit, turnBasedHitpointData) in UnitBaseHitPoints)
       {
-        var bonusPercentage = HitPointPercentagePerTurn * turn;
-        unit.SetMaximumHitpoints((int)(baseHitPoints * (1 + bonusPercentage)));
+        var bonusPercentage = turnBasedHitpointData.HitPointPercentagePerTurn * turn;
+        unit.SetMaximumHitpoints((int)(turnBasedHitpointData.BaseHitPoints * (1 + bonusPercentage)));
         unit.SetCurrentHitpoints(unit.GetMaximumHitPoints());
       }
       
       if (turn >= TurnLimit) 
         GameTime.TurnEnded -= OnTurnEnded;
+    }
+    
+    private sealed class TurnBasedHitpointData
+    {
+      public float HitPointPercentagePerTurn { get; init; }
+      public int BaseHitPoints { get; init; }
     }
   }
 }

--- a/src/MacroTools/TurnBasedHitpointsManager.cs
+++ b/src/MacroTools/TurnBasedHitpointsManager.cs
@@ -34,7 +34,7 @@ namespace MacroTools
       foreach (var (unit, baseHitPoints) in UnitBaseHitPoints)
       {
         var bonusPercentage = HitPointPercentagePerTurn * turn;
-        unit.SetMaximumHitpoints((int)Math.Floor(baseHitPoints * (1 + bonusPercentage)));
+        unit.SetMaximumHitpoints((int)(1 + baseHitPoints * (1 + bonusPercentage)));
         unit.SetCurrentHitpoints(unit.GetMaximumHitPoints());
       }
       

--- a/src/MacroTools/TurnBasedHitpointsManager.cs
+++ b/src/MacroTools/TurnBasedHitpointsManager.cs
@@ -38,7 +38,7 @@ namespace MacroTools
         unit.SetCurrentHitpoints(unit.GetMaximumHitPoints());
       }
       
-      if (turn == TurnLimit) 
+      if (turn >= TurnLimit) 
         GameTime.TurnEnded -= OnTurnEnded;
     }
   }

--- a/src/MacroTools/TurnBasedHitpointsManager.cs
+++ b/src/MacroTools/TurnBasedHitpointsManager.cs
@@ -21,7 +21,7 @@ namespace MacroTools
     public static void Register(unit whichUnit)
     {
       UnitBaseHitPoints.Add(whichUnit, whichUnit.GetMaximumHitPoints());
-      if (!_intialized) 
+      if (_intialized) 
         return;
       
       GameTime.TurnEnded += OnTurnEnded;
@@ -32,8 +32,12 @@ namespace MacroTools
     {
       var turn = GameTime.GetTurn();
       foreach (var (unit, baseHitPoints) in UnitBaseHitPoints)
-        unit.SetMaximumHitpoints((int)(baseHitPoints + turn * HitPointPercentagePerTurn));
-
+      {
+        var bonusPercentage = HitPointPercentagePerTurn * turn;
+        unit.SetMaximumHitpoints((int)Math.Floor(baseHitPoints * (1 + bonusPercentage)));
+        unit.SetCurrentHitpoints(unit.GetMaximumHitPoints());
+      }
+      
       if (turn == TurnLimit) 
         GameTime.TurnEnded -= OnTurnEnded;
     }

--- a/src/MacroTools/TurnBasedHitpointsManager.cs
+++ b/src/MacroTools/TurnBasedHitpointsManager.cs
@@ -9,7 +9,7 @@ namespace MacroTools
   public static class TurnBasedHitpointsManager
   {
     /// <summary>Registered units will gain this many hit points, as a percentage of their maximum, per turn.</summary>
-    private const float HitPointPercentagePerTurn = 0.1f;
+    public const float HitPointPercentagePerTurn = 0.1f;
 
     /// <summary>Past this turn, units will not gain maximum hit points.</summary>
     private const float TurnLimit = 60;

--- a/src/MacroTools/TurnBasedHitpointsManager.cs
+++ b/src/MacroTools/TurnBasedHitpointsManager.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using MacroTools;
 using MacroTools.Extensions;
 using static War3Api.Common;
 
-namespace WarcraftLegacies.Source.GameLogic
+namespace MacroTools
 {
   /// <summary>A tool for giving units additional hit points per turn.</summary>
   public static class TurnBasedHitpointsManager

--- a/src/WarcraftLegacies.Source/Cheats/CheatSkipCinematic.cs
+++ b/src/WarcraftLegacies.Source/Cheats/CheatSkipCinematic.cs
@@ -5,7 +5,7 @@ using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Cheats
 {
-  public sealed class CheatSkipCinematic
+  public static class CheatSkipCinematic
   {
     public static void Init()
     {

--- a/src/WarcraftLegacies.Source/GameLogic/TurnBasedHitpointsManager.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/TurnBasedHitpointsManager.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using MacroTools;
+using MacroTools.Extensions;
+using static War3Api.Common;
+
+namespace WarcraftLegacies.Source.GameLogic
+{
+  /// <summary>A tool for giving units additional hit points per turn.</summary>
+  public static class TurnBasedHitpointsManager
+  {
+    /// <summary>Registered units will gain this many hit points, as a percentage of their maximum, per turn.</summary>
+    private const float HitPointPercentagePerTurn = 0.1f;
+
+    /// <summary>Past this turn, units will not gain maximum hit points.</summary>
+    private const float TurnLimit = 60;
+
+    private static readonly Dictionary<unit, int> UnitBaseHitPoints = new();
+    private static bool _intialized;
+    
+    /// <summary>Causes the unit to continously gain maximum hit points as each turn passes.</summary>
+    public static void Register(unit whichUnit)
+    {
+      UnitBaseHitPoints.Add(whichUnit, whichUnit.GetMaximumHitPoints());
+      if (!_intialized) 
+        return;
+      
+      GameTime.TurnEnded += OnTurnEnded;
+      _intialized = true;
+    }
+
+    private static void OnTurnEnded(object? sender, EventArgs eventArgs)
+    {
+      var turn = GameTime.GetTurn();
+      foreach (var (unit, baseHitPoints) in UnitBaseHitPoints)
+        unit.SetMaximumHitpoints((int)(baseHitPoints + turn * HitPointPercentagePerTurn));
+
+      if (turn == TurnLimit) 
+        GameTime.TurnEnded -= OnTurnEnded;
+    }
+  }
+}

--- a/src/WarcraftLegacies.Source/Setup/CheatSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/CheatSetup.cs
@@ -44,8 +44,8 @@ namespace WarcraftLegacies.Source.Setup
       commandManager.Register(new CheatPosition());
       commandManager.Register(new CheatGetUnitAbilities());
       commandManager.Register(new CheatRemoveAllAbilities());
+      commandManager.Register(new CheatSkipTurns());
       TestMode.Setup(commandManager);
-      var cheatSkipCinematic = new CheatSkipCinematic();
       CheatSkipCinematic.Init();
     }
   }

--- a/src/WarcraftLegacies.Source/Setup/HintSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/HintSetup.cs
@@ -1,3 +1,4 @@
+using MacroTools;
 using MacroTools.HintSystem;
 using WarcraftLegacies.Source.GameLogic.GameEnd;
 
@@ -7,28 +8,21 @@ namespace WarcraftLegacies.Source.Setup
   {
     public static void Setup()
     {
-      Hint.Register(new Hint(
-        "Quests are unique objectives that grant rewards when completed. View the Quest Menu (F9) to see the quests available to your faction."));
-      Hint.Register(new Hint(
-        "Artifacts are unique items that can grant major advantages. You can find out where Artifacts are using the Artifact Menu at the top-left of your screen."));
-      Hint.Register(new Hint(
-        "Some heroes can't be revived, and some can only be revived if you control certain capitals when they die."));
+      Hint.Register(new Hint("Quests are unique objectives that grant rewards when completed. View the Quest Menu (F9) to see the quests available to your faction."));
+      Hint.Register(new Hint("Artifacts are unique items that can grant major advantages. You can find out where Artifacts are using the Artifact Menu at the top-left of your screen."));
+      Hint.Register(new Hint("Some heroes can't be revived, and some can only be revived if you control certain capitals when they die."));
       Hint.Register(new Hint("If you have low FPS, try turning off your health bars."));
       Hint.Register(new Hint("We have a welcoming Discord community at https:;//discord.gg//4eGZn"));
-      Hint.Register(new Hint(
-        "When a player leaves, their gold, lumber, units and hero experience are spread among their remaining allies."));
-      Hint.Register(new Hint(
-        "There are water passageways at the edge of the map you can use to instantly move to the other side of the map."));
+      Hint.Register(new Hint("When a player leaves, their gold, lumber, units and hero experience are spread among their remaining allies."));
+      Hint.Register(new Hint("There are water passageways at the edge of the map you can use to instantly move to the other side of the map."));
       Hint.Register(new Hint("Every faction can build an item shop that contains useful purchasable items."));
-      Hint.Register(new Hint(
-        "When you unlock a hero through a Quest, you usually still need to summon that hero from an Altar."));
-      Hint.Register(new Hint(
-        "Workers don't need to return their lumber to a Town Hall or Lumber mill, unlike in melee gameplay."));
+      Hint.Register(new Hint("When you unlock a hero through a Quest, you usually still need to summon that hero from an Altar."));
+      Hint.Register(new Hint("Workers don't need to return their lumber to a Town Hall or Lumber mill, unlike in melee gameplay."));
       Hint.Register(new Hint("The best way to travel between continent is to use Town portal scrolls!"));
-      Hint.Register(
-        new Hint("If you want to support the team, support our Patreon at: https:;//www.patreon.com/lordsebas"));
+      Hint.Register(new Hint("If you want to support the team, support our Patreon at: https:;//www.patreon.com/lordsebas"));
       Hint.Register(new Hint("Control Points have towers which get stronger every turn, or when you research Fortify."));
       Hint.Register(new Hint($"Win the game by capturing {ControlPointVictory.CpsVictory} Control Points."));
+      Hint.Register(new Hint($"Each turn, every Capital and every gate gains {TurnBasedHitpointsManager.HitPointPercentagePerTurn}% bonus maximum hit points."));
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Setup/HintSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/HintSetup.cs
@@ -1,5 +1,7 @@
 using MacroTools;
 using MacroTools.HintSystem;
+using MacroTools.Instances;
+using MacroTools.LegendSystem;
 using WarcraftLegacies.Source.GameLogic.GameEnd;
 
 namespace WarcraftLegacies.Source.Setup
@@ -22,7 +24,7 @@ namespace WarcraftLegacies.Source.Setup
       Hint.Register(new Hint("If you want to support the team, support our Patreon at: https:;//www.patreon.com/lordsebas"));
       Hint.Register(new Hint("Control Points have towers which get stronger every turn, or when you research Fortify."));
       Hint.Register(new Hint($"Win the game by capturing {ControlPointVictory.CpsVictory} Control Points."));
-      Hint.Register(new Hint($"Each turn, every Capital and every gate gains {TurnBasedHitpointsManager.HitPointPercentagePerTurn}% bonus maximum hit points."));
+      Hint.Register(new Hint($"Each turn, every Capital and every gate gains bonus maximum hit points. Capitals gain {CapitalManager.HitPointPercentagePerTurn*100}% and gates gain {MacroTools.PassiveAbilities.Gate.HitPointPercentagePerTurn*100}%."));
     }
   }
 }


### PR DESCRIPTION
I also added the -skipturns x cheat to make testing this easier. You can configure the system in `CapitalManager.cs`, `TurnBasedHitPointManager.cs`, and `Gate.cs`.