### PR TITLE
Make undroppable Artifacts droppable when the Legend first dies

### DIFF
--- a/src/MacroTools/ArtifactSystem/Artifact.cs
+++ b/src/MacroTools/ArtifactSystem/Artifact.cs
@@ -2,7 +2,6 @@ using System;
 using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using WCSharp.Events;
-using WCSharp.Shared.Data;
 using static War3Api.Common;
 
 namespace MacroTools.ArtifactSystem
@@ -12,7 +11,6 @@ namespace MacroTools.ArtifactSystem
   /// </summary>
   public sealed class Artifact
   {
-    private string? _description;
     private ArtifactLocationType _locationType;
     private unit? _owningUnit;
     private int _titanforgedAbility = FourCC("A0VJ");
@@ -41,13 +39,7 @@ namespace MacroTools.ArtifactSystem
     /// <summary>
     ///   The real <see cref="item" /> that the <see cref="Artifact" /> is representing.
     /// </summary>
-    public item Item { get; private set; }
-
-    /// <summary>
-    ///   A pretend-position. The player can ping this position instead of the item's real position if
-    ///   <see cref="ArtifactLocationType" /> is set to <see cref="ArtifactLocationType.Special" />.
-    /// </summary>
-    public Point FalsePosition { get; set; } = new(0, 0);
+    public item Item { get; }
 
     /// <summary>
     ///   The extra ability the Artifact gains when it's Titanforged.
@@ -67,7 +59,7 @@ namespace MacroTools.ArtifactSystem
     /// </summary>
     public ArtifactLocationType LocationType
     {
-      set
+      private set
       {
         _locationType = value;
         StatusChanged?.Invoke(this, this);
@@ -87,20 +79,6 @@ namespace MacroTools.ArtifactSystem
         if (OwningPlayer != GetOwningPlayer(value)) 
           SetOwningPlayer(value != null ? GetOwningPlayer(value) : null);
       }
-    }
-
-    /// <summary>
-    ///   A user-friendly description of the <see cref="Artifact" />'s location.
-    ///   Only displayed when <see cref="LocationType" /> is set to <see cref="ArtifactLocationType.Hidden" />.
-    /// </summary>
-    public string LocationDescription
-    {
-      set
-      {
-        _description = value;
-        DescriptionChanged?.Invoke(this, this);
-      }
-      get => _description ?? "";
     }
 
     /// <summary>
@@ -141,11 +119,6 @@ namespace MacroTools.ArtifactSystem
     public event EventHandler<Artifact>? StatusChanged;
 
     /// <summary>
-    ///   Any <see cref="Artifact" /> has its description changed.
-    /// </summary>
-    public event EventHandler<Artifact>? DescriptionChanged;
-
-    /// <summary>
     ///   Grant the Artifact a predefined bonus ability.
     /// </summary>
     public void Titanforge()
@@ -166,9 +139,7 @@ namespace MacroTools.ArtifactSystem
     {
       if (GetLocalPlayer() != whichPlayer) 
         return;
-      if (_locationType == ArtifactLocationType.Special)
-        PingMinimap(FalsePosition.X, FalsePosition.Y, 3);
-      else if (_owningUnit != null)
+      if (_owningUnit != null)
         PingMinimap(GetUnitX(_owningUnit), GetUnitY(_owningUnit), 3);
       else
         PingMinimap(GetItemX(Item), GetItemY(Item), 3);

--- a/src/MacroTools/ArtifactSystem/ArtifactLocationType.cs
+++ b/src/MacroTools/ArtifactSystem/ArtifactLocationType.cs
@@ -5,21 +5,10 @@
   /// </summary>
   public enum ArtifactLocationType
   {
-    /// <summary>
-    /// Artifact is on the ground.
-    /// </summary>
+    /// <summary>Artifact is on the ground.</summary>
     Ground,
-    /// <summary>
-    /// Artifact is held by a unit.
-    /// </summary>
-    Unit,
-    /// <summary>
-    /// Artifact is nowhere, but has a pretend-location that the player can ping.
-    /// </summary>
-    Special,
-    /// <summary>
-    /// Artifact does not allow pinging, and only displays text describing its pretend-location.
-    /// </summary>
-    Hidden
+    
+    /// <summary>Artifact is held by a unit.</summary>
+    Unit
   }
 }

--- a/src/MacroTools/ArtifactSystem/ArtifactManager.cs
+++ b/src/MacroTools/ArtifactSystem/ArtifactManager.cs
@@ -93,7 +93,7 @@ namespace MacroTools.ArtifactSystem
           for (var i = 0; i < 6; i++)
           {
             var itemInSlot = UnitItemInSlot(triggerUnit, i);
-            if (itemInSlot == null)
+            if (itemInSlot == null || !itemInSlot.IsDroppable())
               continue;
             
             var artifactInSlot = GetFromTypeId(GetItemTypeId(itemInSlot));
@@ -103,9 +103,7 @@ namespace MacroTools.ArtifactSystem
             isPositionPathable ??= !IsTerrainPathable(GetUnitX(triggerUnit), GetUnitY(triggerUnit), PATHING_TYPE_WALKABILITY);
 
             if (isPositionPathable == true)
-            {
               itemInSlot.SetPosition(triggerUnit.GetPosition());
-            }
             else
             {
               var shore = ShoreManager.GetNearestShore(triggerUnit.GetPosition());

--- a/src/MacroTools/BookSystem/ArtifactSystem/ArtifactCard.cs
+++ b/src/MacroTools/BookSystem/ArtifactSystem/ArtifactCard.cs
@@ -73,7 +73,7 @@ namespace MacroTools.BookSystem.ArtifactSystem
     }
 
     /// <summary>
-    /// Updates the description to reflect current <see cref="Artifact.LocationType"/> and <see cref="Artifact.LocationDescription"/> settings.
+    /// Updates the description to reflect current <see cref="Artifact.LocationType"/> settings.
     /// </summary>
     private void RefreshLocationDescriptionFrame()
     {
@@ -95,15 +95,6 @@ namespace MacroTools.BookSystem.ArtifactSystem
         case ArtifactLocationType.Ground:
           _text.Visible = false;
           _pingButton.Visible = true;
-          break;
-        case ArtifactLocationType.Special:
-          _text.Visible = false;
-          _pingButton.Visible = true;
-          break;
-        case ArtifactLocationType.Hidden:
-          _text.Visible = true;
-          _pingButton.Visible = false;
-          _text.Text = _artifact.LocationDescription;
           break;
         default:
           throw new InvalidEnumArgumentException();

--- a/src/MacroTools/Cheats/CheatPermaKill.cs
+++ b/src/MacroTools/Cheats/CheatPermaKill.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using MacroTools.CommandSystem;
+using MacroTools.Extensions;
+using MacroTools.LegendSystem;
+using static War3Api.Common;
+
+namespace MacroTools.Cheats
+{
+  public sealed class CheatPermaKill : Command
+  {
+    /// <inheritdoc />
+    public override string CommandText => "permakill";
+
+    /// <inheritdoc />
+    public override bool Exact => true;
+
+    /// <inheritdoc />
+    public override int MinimumParameterCount => 0;
+
+    /// <inheritdoc />
+    public override CommandType Type => CommandType.Cheat;
+
+    /// <inheritdoc />
+    public override string Description => "Permanently kills the selected Legends.";
+
+    /// <inheritdoc />
+    public override string Execute(player cheater, params string[] parameters)
+    {
+      var selectedUnits = CreateGroup().EnumSelectedUnits(cheater).EmptyToList();
+      if (!selectedUnits.Any())
+        return "You're not selecting any Legends.";
+      
+      foreach (var unit in selectedUnits)
+      {
+        var asLegend = LegendaryHeroManager.GetFromUnit(unit);
+        asLegend?.PermanentlyKill();
+      }
+
+      return "Permanently killed all selected Legends.";
+    }
+  }
+}

--- a/src/MacroTools/Extensions/ItemExtensions.cs
+++ b/src/MacroTools/Extensions/ItemExtensions.cs
@@ -15,7 +15,9 @@ namespace MacroTools.Extensions
       SetItemDroppable(whichItem, canBeDropped);
       return whichItem;
     }
-    
+
+    public static bool IsDroppable(this item whichItem) => BlzGetItemBooleanField(whichItem, ITEM_BF_CAN_BE_DROPPED);
+
     /// <summary>
     /// Drop the item at the given position. If the position turns out to be non-ground-pathable,
     /// return it to a nearby <see cref="Shore"/> instead.

--- a/src/MacroTools/Extensions/UnitExtensions.cs
+++ b/src/MacroTools/Extensions/UnitExtensions.cs
@@ -566,8 +566,9 @@ namespace MacroTools.Extensions
         var y = unitY + HeroDropDist * Sin(angInRadians);
         angInRadians += 360 * MathEx.DegToRad / 6;
         var itemToDrop = UnitItemInSlot(whichUnit, i);
-        if (!BlzGetItemBooleanField(itemToDrop, ITEM_BF_DROPPED_WHEN_CARRIER_DIES) &&
-            !BlzGetItemBooleanField(itemToDrop, ITEM_BF_CAN_BE_DROPPED)) continue;
+        if (!itemToDrop.IsDroppable())
+          itemToDrop.SetDroppable(true);
+
         whichUnit.DropItem(itemToDrop);
         itemToDrop.SetPositionSafe(new Point(x, y));
       }

--- a/src/MacroTools/LegendSystem/LegendaryHero.cs
+++ b/src/MacroTools/LegendSystem/LegendaryHero.cs
@@ -159,6 +159,16 @@ namespace MacroTools.LegendSystem
       RefreshDummy();
     }
     
+    /// <summary>Permanently kills the <see cref="LegendaryHero"/>, preventing it from ever being revived.</summary>
+    public void PermanentlyKill()
+    {
+      if (Hivemind && OwningPlayer != null)
+        PlayerDistributor.DistributePlayer(OwningPlayer);
+      
+      OnPermaDeath();
+      PermanentlyDied?.Invoke(this, this);
+    }
+    
     private void OnDeath()
     {
       if (!_permaDies && !AllDependenciesAreMissing()) 
@@ -234,16 +244,6 @@ namespace MacroTools.LegendSystem
         GetOwningPlayer(Unit) == Player(PLAYER_NEUTRAL_AGGRESSIVE)
           ? $"\n|cffffcc00LEGENDARY FOE SLAIN|r\n{DeathMessage}"
           : $"\n|cffffcc00HERO SLAIN|r\n{DeathMessage}");
-    }
-
-    private void PermanentlyKill()
-    {
-      if (Hivemind && OwningPlayer != null)
-        PlayerDistributor.DistributePlayer(OwningPlayer);
-
-
-      OnPermaDeath();
-      PermanentlyDied?.Invoke(this, this);
     }
     
     private void RefreshDummy()

--- a/src/MacroTools/LegendSystem/LegendaryHero.cs
+++ b/src/MacroTools/LegendSystem/LegendaryHero.cs
@@ -95,9 +95,9 @@ namespace MacroTools.LegendSystem
     public string DeathSfx { private get; init; } = @"Abilities\Spells\Demon\DarkPortal\DarkPortalTarget.mdl";
 
     /// <summary>
-    /// The <see cref="LegendaryHero"/> will spawn with <see cref="Artifact"/>s with these IDs the first time they are created.
+    /// The <see cref="LegendaryHero"/> will spawn with these <see cref="Artifact"/>s the first time they are created.
     /// </summary>
-    public List<int> StartingArtifactItemTypeIds { get; init; } = new();
+    public List<Artifact> StartingArtifacts { get; init; } = new();
     
     /// <summary>
     /// Initializes a new instance of the <see cref="LegendaryHero"/> class.
@@ -201,15 +201,14 @@ namespace MacroTools.LegendSystem
       SetUnitColor(Unit, HasCustomColor ? _playerColor : GetPlayerColor(GetOwningPlayer(Unit)));
       if (GetHeroXP(Unit) < StartingXp) 
         SetHeroXP(Unit, StartingXp, true);
-      if (StartingArtifactItemTypeIds.Any())
+      if (StartingArtifacts.Any())
       {
-        foreach (var artifactItemTypeId in StartingArtifactItemTypeIds)
+        foreach (var artifact in StartingArtifacts)
         {
-          var artifact = new Artifact(CreateItem(artifactItemTypeId, 0, 0));
           ArtifactManager.Register(artifact);
           Unit.AddItemSafe(artifact.Item);
         }
-        StartingArtifactItemTypeIds.Clear();
+        StartingArtifacts.Clear();
       }
       
       RefreshDummy();

--- a/src/WarcraftLegacies.Source/Setup/CheatSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/CheatSetup.cs
@@ -45,6 +45,7 @@ namespace WarcraftLegacies.Source.Setup
       commandManager.Register(new CheatGetUnitAbilities());
       commandManager.Register(new CheatRemoveAllAbilities());
       commandManager.Register(new CheatSkipTurns());
+      commandManager.Register(new CheatPermaKill());
       TestMode.Setup(commandManager);
       CheatSkipCinematic.Init();
     }

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendDruids.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendDruids.cs
@@ -33,9 +33,9 @@ namespace WarcraftLegacies.Source.Setup.Legends
       Malfurion = new LegendaryHero("Malfurion")
       {
         UnitType = FourCC("Efur"),
-        StartingArtifactItemTypeIds = new()
+        StartingArtifacts = new()
         {
-          Constants.ITEM_I00C_G_HANIR_THE_MOTHER_TREE
+          new(CreateItem(Constants.ITEM_I00C_G_HANIR_THE_MOTHER_TREE, Regions.ArtifactDummyInstance.Center.X, Regions.ArtifactDummyInstance.Center.Y))
         }
       };
 

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendFrostwolf.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendFrostwolf.cs
@@ -27,9 +27,9 @@ namespace WarcraftLegacies.Source.Setup.Legends
       Thrall = new LegendaryHero("Thrall")
       {
         UnitType = Constants.UNIT_OTHR_WARCHIEF_OF_THE_HORDE_FROSTWOLF,
-        StartingArtifactItemTypeIds = new()
+        StartingArtifacts = new()
         {
-          Constants.ITEM_I004_THE_DOOMHAMMER
+          new(CreateItem(Constants.ITEM_I004_THE_DOOMHAMMER, Regions.ArtifactDummyInstance.Center.X, Regions.ArtifactDummyInstance.Center.Y))
         }
       };
 

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendLordaeron.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendLordaeron.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
 using MacroTools;
+using MacroTools.ArtifactSystem;
 using MacroTools.Extensions;
 using MacroTools.LegendSystem;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
+
 #pragma warning disable CS1591
 
 namespace WarcraftLegacies.Source.Setup.Legends
@@ -34,20 +36,20 @@ namespace WarcraftLegacies.Source.Setup.Legends
         Unit = preplacedUnitSystem.GetUnit(Constants.UNIT_NEMI_KING_TERENAS_MENETHIL_LORDAERON)
       };
       CreateTrigger()
-       .RegisterUnitEvent(Terenas.Unit, EVENT_UNIT_DEATH)
-       .AddAction(() =>
-       {
-         if (artifactSetup.CrownOfLordaeron.OwningUnit == Terenas.Unit)
-           artifactSetup.CrownOfLordaeron.Item.SetPosition(Regions.King_Arthas_crown.Center);
-       });
+        .RegisterUnitEvent(Terenas.Unit, EVENT_UNIT_DEATH)
+        .AddAction(() =>
+        {
+          if (artifactSetup.CrownOfLordaeron.OwningUnit == Terenas.Unit)
+            artifactSetup.CrownOfLordaeron.Item.SetPosition(Regions.King_Arthas_crown.Center);
+        });
 
       Mograine = new LegendaryHero("Alexandros Mograine")
       {
         UnitType = Constants.UNIT_H01J_THE_ASHBRINGER_LORDAERON,
         StartingXp = 5400,
-        StartingArtifactItemTypeIds = new List<int>
+        StartingArtifacts = new List<Artifact>
         {
-          Constants.ITEM_I012_ASHBRINGER
+          new(CreateItem(Constants.ITEM_I012_ASHBRINGER, Regions.ArtifactDummyInstance.Center.X, Regions.ArtifactDummyInstance.Center.Y))
         }
       };
 
@@ -69,10 +71,14 @@ namespace WarcraftLegacies.Source.Setup.Legends
         DeathMessage = "The capital city of Lordaeron has been razed, and King Terenas is dead.",
         Essential = true
       };
-      CapitalPalace.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H006_IMPROVED_GUARD_TOWER_LORDAERON_TOWER, new Point(8686, 8862)));
-      CapitalPalace.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H006_IMPROVED_GUARD_TOWER_LORDAERON_TOWER, new Point(9476, 8843)));
-      CapitalPalace.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER, new Point(8638, 9342)));
-      CapitalPalace.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER, new Point(9545, 9372)));
+      CapitalPalace.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H006_IMPROVED_GUARD_TOWER_LORDAERON_TOWER,
+        new Point(8686, 8862)));
+      CapitalPalace.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H006_IMPROVED_GUARD_TOWER_LORDAERON_TOWER,
+        new Point(9476, 8843)));
+      CapitalPalace.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER,
+        new Point(8638, 9342)));
+      CapitalPalace.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER,
+        new Point(9545, 9372)));
       CreateTrigger()
         .RegisterUnitEvent(CapitalPalace.Unit, EVENT_UNIT_DEATH)
         .AddAction(() =>
@@ -94,8 +100,10 @@ namespace WarcraftLegacies.Source.Setup.Legends
         DeathMessage = "The majestic city of Stratholme has been destroyed.",
         Essential = true
       };
-      Stratholme.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER, new Point(14587, 14172)));
-      Stratholme.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H006_IMPROVED_GUARD_TOWER_LORDAERON_TOWER, new Point(15800, 13242)));
+      Stratholme.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER,
+        new Point(14587, 14172)));
+      Stratholme.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H006_IMPROVED_GUARD_TOWER_LORDAERON_TOWER,
+        new Point(15800, 13242)));
 
       TyrsHand = new Capital
       {
@@ -103,9 +111,12 @@ namespace WarcraftLegacies.Source.Setup.Legends
         DeathMessage = "Tyr's Hand, the bastion of human power in Lordaeron, has fallen.",
         Essential = true
       };
-      TyrsHand.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_HCTW_CANNON_TOWER_LORDAERON_TOWER, new Point(20652, 8057)));
-      TyrsHand.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER, new Point(20024, 8123)));
-      TyrsHand.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER, new Point(20042, 7420)));
+      TyrsHand.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_HCTW_CANNON_TOWER_LORDAERON_TOWER,
+        new Point(20652, 8057)));
+      TyrsHand.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER,
+        new Point(20024, 8123)));
+      TyrsHand.AddProtector(preplacedUnitSystem.GetUnit(Constants.UNIT_H007_IMPROVED_CANNON_TOWER_LORDAERON_TOWER,
+        new Point(20042, 7420)));
 
       Uther = new LegendaryHero("Uther the Lightbringer")
       {
@@ -128,7 +139,6 @@ namespace WarcraftLegacies.Source.Setup.Legends
         Capturable = true
       };
     }
-
 
 
     public void RegisterLegends()

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendNeutral.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendNeutral.cs
@@ -34,9 +34,9 @@ namespace WarcraftLegacies.Source.Setup.Legends
       {
         UnitType = Constants.UNIT_N00D_PRIMARY_FIRELORD_CREEP,
         DeathMessage = "Ragnaros, the King of Fire and Lord of the Firelands, has been extinguished.",
-        StartingArtifactItemTypeIds = new()
+        StartingArtifacts = new()
         {
-          Constants.ITEM_I00H_SULFURAS_HAND_OF_RAGNAROS
+          new(CreateItem(Constants.ITEM_I00H_SULFURAS_HAND_OF_RAGNAROS, Regions.ArtifactDummyInstance.Center.X, Regions.ArtifactDummyInstance.Center.Y))
         },
         StartingXp = 15404
       };

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendQuelthalas.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendQuelthalas.cs
@@ -44,9 +44,9 @@ namespace WarcraftLegacies.Source.Setup.Legends
         UnitType = Constants.UNIT_H00Q_KING_OF_QUEL_THALAS_QUEL_THALAS,
         PlayerColor = PLAYER_COLOR_MAROON,
         StartingXp = 1000,
-        StartingArtifactItemTypeIds = new()
+        StartingArtifacts = new()
         {
-          Constants.ITEM_I00J_FELO_MELORN
+          new(CreateItem(Constants.ITEM_I00J_FELO_MELORN, Regions.ArtifactDummyInstance.Center.X, Regions.ArtifactDummyInstance.Center.Y))
         }
       };
 

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendStormwind.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendStormwind.cs
@@ -1,6 +1,7 @@
 ﻿using MacroTools;
 using MacroTools.LegendSystem;
 using WCSharp.Shared.Data;
+using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Setup.Legends
 {
@@ -22,9 +23,9 @@ namespace WarcraftLegacies.Source.Setup.Legends
         UnitType = Constants.UNIT_H00R_KING_OF_STORMWIND_DARK_GREEN,
         DeathMessage = "The King of Stormwind dies a warrior’s death, defending hearth and family. The Wrynn Dynasty crumbles with his passing.",
         StartingXp = 1800,
-        StartingArtifactItemTypeIds = new()
+        StartingArtifacts = new()
         {
-          Constants.ITEM_I00D_SHALAMAYNE
+          new(CreateItem(Constants.ITEM_I00D_SHALAMAYNE, Regions.ArtifactDummyInstance.Center.X, Regions.ArtifactDummyInstance.Center.Y))
         }
       };
 
@@ -32,7 +33,10 @@ namespace WarcraftLegacies.Source.Setup.Legends
       {
         UnitType = Constants.UNIT_H00Z_CROWN_PRINCE_OF_STROMGARDE_STORMWIND,
         StartingXp = 5400,
-        StartingArtifactItemTypeIds = new() { Constants.ITEM_I01O_TROL_KALAR }
+        StartingArtifacts = new()
+        {
+          new(CreateItem(Constants.ITEM_I01O_TROL_KALAR, Regions.ArtifactDummyInstance.Center.X, Regions.ArtifactDummyInstance.Center.Y))
+        }
       };
 
       Bolvar = new LegendaryHero("Bolvar Fordragon")

--- a/src/WarcraftLegacies.Source/Setup/Legends/LegendWarsong.cs
+++ b/src/WarcraftLegacies.Source/Setup/Legends/LegendWarsong.cs
@@ -1,5 +1,6 @@
 ﻿using MacroTools;
 using MacroTools.LegendSystem;
+using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.Setup.Legends
 {
@@ -19,9 +20,9 @@ namespace WarcraftLegacies.Source.Setup.Legends
       GromHellscream = new LegendaryHero("Grom Hellscream")
       {
         UnitType = Constants.UNIT_OGRH_CHIEFTAIN_OF_THE_WARSONG_CLAN_WARSONG,
-        StartingArtifactItemTypeIds = new()
+        StartingArtifacts = new()
         {
-          Constants.ITEM_I01V_GOREHOWL
+          new(CreateItem(Constants.ITEM_I01V_GOREHOWL, Regions.ArtifactDummyInstance.Center.X, Regions.ArtifactDummyInstance.Center.Y))
         }
       };
       


### PR DESCRIPTION
Currently the Ashbringer is undroppable, but still drops when Mograine first dies. This makes it undroppable until he _permanently_ dies, but after that, it becomes fully droppable.