### PR TITLE
Clearly convey which Faction is more difficult than the other in the Faction selection screen

### DIFF
--- a/src/MacroTools/FactionChoices/FactionChoiceDialogPresenter.cs
+++ b/src/MacroTools/FactionChoices/FactionChoiceDialogPresenter.cs
@@ -6,13 +6,13 @@ using MacroTools.FactionSystem;
 using MacroTools.UserInterface;
 using static War3Api.Common;
 
-namespace WarcraftLegacies.Source.GameLogic
+namespace MacroTools.FactionChoices
 {
   /// <summary>Allows a player to choose between one of two factions at the start of the game.</summary>
   public sealed class FactionChoiceDialogPresenter : ChoiceDialogPresenter<Faction>
   {
     /// <summary>Initializes a new instance of the <see cref="FactionChoiceDialogPresenter"/> class.</summary>
-    public FactionChoiceDialogPresenter(params Faction[] factions) : base(ConvertFactionsToFactionChoices(factions),
+    public FactionChoiceDialogPresenter(params Faction[] factions) : base(ConvertToFactionChoices(factions),
       "Pick your Faction")
     {
     }
@@ -61,7 +61,11 @@ namespace WarcraftLegacies.Source.GameLogic
       faction.Defeat();
     }
     
-    private static Choice<Faction>[] ConvertFactionsToFactionChoices(IEnumerable<Faction> factions) =>
-      factions.Select(x => new Choice<Faction>(x, x.Name)).ToArray();
+    private static Choice<Faction>[] ConvertToFactionChoices(IEnumerable<Faction> factions)
+    {
+      return factions
+        .Select(x => new Choice<Faction>(x, $"{x.Name} {x.LearningDifficulty.ToColoredText()}"))
+        .ToArray();
+    }
   }
 }

--- a/src/MacroTools/FactionChoices/FactionLearningDifficulty.cs
+++ b/src/MacroTools/FactionChoices/FactionLearningDifficulty.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using MacroTools.FactionSystem;
+
+namespace MacroTools.FactionChoices
+{
+  /// <summary>
+  /// Indicates how difficult it is to learn the basic mechanics of a particular <see cref="Faction"/>.
+  /// </summary>
+  public enum FactionLearningDifficulty
+  {
+    Basic,
+    Advanced
+  }
+
+  public static class FactionLearningDifficultyExtensions
+  {
+    public static string ToColoredText(this FactionLearningDifficulty difficulty)
+    {
+      switch (difficulty)
+      {
+        case FactionLearningDifficulty.Basic:
+          return "|c0096FF96(Basic)|r";
+        case FactionLearningDifficulty.Advanced:
+          return "|c00FF7F00(Advanced)|r";
+        default:
+          throw new ArgumentOutOfRangeException(nameof(difficulty), difficulty, null);
+      }
+    }
+  }
+}

--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using MacroTools.ControlPointSystem;
 using MacroTools.Extensions;
+using MacroTools.FactionChoices;
 using MacroTools.LegendSystem;
 using MacroTools.ObjectiveSystem.Objectives;
 using MacroTools.QuestSystem;
@@ -134,6 +135,14 @@ namespace MacroTools.FactionSystem
     /// <summary>Whether or not the <see cref="Faction"/> has been defeated.</summary>
     public ScoreStatus ScoreStatus { get; private set; } = ScoreStatus.Undefeated;
 
+    /// <summary>
+    /// Indicates how difficult it is to learn the basic mechanics of this <see cref="Faction"/>.
+    /// <para>This isn't about how difficult the Faction is to play optimally, but rather how difficult it is to
+    /// play at a very basic level. For instance, a Faction with a very complex starting quest would be very hard
+    /// even if it doesn't have to perform a lot of micro in fights.</para>
+    /// </summary>
+    public FactionLearningDifficulty LearningDifficulty { get; init; }
+    
     public string ColoredName => $"{PrefixCol}{_name}|r";
 
     public string PrefixCol { get; }

--- a/src/MacroTools/UserInterface/Choice.cs
+++ b/src/MacroTools/UserInterface/Choice.cs
@@ -4,12 +4,12 @@
   public sealed class Choice<T>
   {
     /// <summary>Internal data that the choice needs to know about.</summary>
-    public T? Data { get; }
+    public T Data { get; }
 
     /// <summary>The text shown to the player.</summary>
     public string Name { get; }
 
-    public Choice(T? data, string name)
+    public Choice(T data, string name)
     {
       Data = data;
       Name = name;

--- a/src/WarcraftLegacies.Source/GameLogic/ScourgeInvasionDialogPresenter.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/ScourgeInvasionDialogPresenter.cs
@@ -6,14 +6,14 @@ using static War3Api.Common;
 
 namespace WarcraftLegacies.Source.GameLogic
 {
-  public sealed class ScourgeInvasionDialogPresenter : ChoiceDialogPresenter<Rectangle>
+  public sealed class ScourgeInvasionDialogPresenter : ChoiceDialogPresenter<Rectangle?>
   {
-    public ScourgeInvasionDialogPresenter(params Choice<Rectangle>[] invasionTargets) : base(invasionTargets,
+    public ScourgeInvasionDialogPresenter(params Choice<Rectangle?>[] invasionTargets) : base(invasionTargets,
       "Pick invasion location")
     {
     }
 
-    protected override void OnChoicePicked(player pickingPlayer, Choice<Rectangle> choice)
+    protected override void OnChoicePicked(player pickingPlayer, Choice<Rectangle?> choice)
     {
       HasChoiceBeenPicked = true;
       if (choice.Data == null)
@@ -38,7 +38,7 @@ namespace WarcraftLegacies.Source.GameLogic
         SetCameraPosition(invasionLocation.Center.X, invasionLocation.Center.Y);
     }
 
-    protected override void OnChoiceExpired(player pickingPlayer, Choice<Rectangle> choice)
+    protected override void OnChoiceExpired(player pickingPlayer, Choice<Rectangle?> choice)
     {
       if (GetLocalPlayer() == pickingPlayer)
         DialogDisplay(GetLocalPlayer(), PickDialog, false);

--- a/src/WarcraftLegacies.Source/Setup/FactionChoiceDialogSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionChoiceDialogSetup.cs
@@ -1,0 +1,16 @@
+﻿using MacroTools.FactionChoices;
+using WarcraftLegacies.Source.Setup.FactionSetup;
+using static War3Api.Common;
+
+namespace WarcraftLegacies.Source.Setup
+{
+  public static class FactionChoiceDialogSetup
+  {
+    public static void Setup()
+    {
+      new FactionChoiceDialogPresenter(ZandalarSetup.Zandalar, GoblinSetup.Goblin).Run(Player(8));
+      new FactionChoiceDialogPresenter(IllidariSetup.Illidari, SunfurySetup.Sunfury).Run(Player(15));
+      new FactionChoiceDialogPresenter(DalaranSetup.Dalaran, GilneasSetup.Gilneas).Run(Player(7));
+    }
+  }
+}

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/DalaranSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/DalaranSetup.cs
@@ -1,5 +1,6 @@
 ﻿using MacroTools;
 using MacroTools.Extensions;
+using MacroTools.FactionChoices;
 using MacroTools.FactionSystem;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
@@ -22,6 +23,7 @@ namespace WarcraftLegacies.Source.Setup.FactionSetup
         ControlPointDefenderUnitTypeId = Constants.UNIT_N00N_CONTROL_POINT_DEFENDER_DALARAN,
         StartingCameraPosition = Regions.DalaStartPos.Center,
         StartingUnits = Regions.DalaStartPos.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable),
+        LearningDifficulty = FactionLearningDifficulty.Basic,
         IntroText = @"You are playing the wise |cffff8080Council of Dalaran|r.
 
 You begin in the Hillsbrad Foothills, separated from the main forces of Dalaran. To unlock Dalaran you must capture Shadowfang Keep, which have been encircled by monsters.

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/GilneasSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/GilneasSetup.cs
@@ -1,5 +1,6 @@
 ﻿using MacroTools;
 using MacroTools.Extensions;
+using MacroTools.FactionChoices;
 using MacroTools.FactionSystem;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
@@ -20,6 +21,7 @@ namespace WarcraftLegacies.Source.Setup.FactionSetup
         ControlPointDefenderUnitTypeId = Constants.UNIT_H0AF_CONTROL_POINT_DEFENDER_GILNEAS,
         StartingCameraPosition = Regions.GilneasStartPos.Center,
         StartingUnits = Regions.GilneasStartPos.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable),
+        LearningDifficulty = FactionLearningDifficulty.Advanced,
         IntroText = @"You are playing as the accursed |cff646464Kingdom of Gilneas|r|r.
 
 You start isolated behind the Greymane Wall, the only way for an enemy to reach you is through the Greymane Gate or via the coast.

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/GoblinSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/GoblinSetup.cs
@@ -1,5 +1,6 @@
 ﻿using MacroTools;
 using MacroTools.Extensions;
+using MacroTools.FactionChoices;
 using MacroTools.FactionSystem;
 using MacroTools.Powers;
 using WCSharp.Shared.Data;
@@ -23,6 +24,7 @@ namespace WarcraftLegacies.Source.Setup.FactionSetup
         StartingLumber = 700,
         ControlPointDefenderUnitTypeId = Constants.UNIT_O01C_CONTROL_POINT_DEFENDER_GOBLIN,
         StartingUnits = Regions.GoblinStartPos.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable),
+        LearningDifficulty = FactionLearningDifficulty.Advanced,
         IntroText = @"You are playing as the industrious |cff808080Bilgewater Cartel|r.
 
 You begin in Tanaris with a very small business venture. Expand onto Kalimdor to grow your trade empire.

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/IllidariSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/IllidariSetup.cs
@@ -1,4 +1,5 @@
 ﻿using MacroTools.Extensions;
+using MacroTools.FactionChoices;
 using MacroTools.FactionSystem;
 using static War3Api.Common;
 
@@ -20,6 +21,7 @@ namespace WarcraftLegacies.Source.Setup.FactionSetup
         StartingCameraPosition = Regions.IllidanStartingPosition.Center,
         StartingUnits = Regions.IllidanStartingPosition.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable),
         ControlPointDefenderUnitTypeId = Constants.UNIT_N0BB_CONTROL_POINT_DEFENDER_ILLIDARI_TOWER,
+        LearningDifficulty = FactionLearningDifficulty.Basic,
         IntroText = @"You are playing as the Betrayer, Illidan|r|r.
 
 You begin on the Broken Isles, ready to plunder the tombs for artifacts to empower Illidan.

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/SunfurySetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/SunfurySetup.cs
@@ -1,5 +1,6 @@
 ﻿using MacroTools;
 using MacroTools.Extensions;
+using MacroTools.FactionChoices;
 using MacroTools.FactionSystem;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
@@ -22,6 +23,7 @@ namespace WarcraftLegacies.Source.Setup.FactionSetup
         StartingCameraPosition = Regions.SunfuryStartingPosition.Center,
         StartingUnits = Regions.SunfuryStartingPosition.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable),
         ControlPointDefenderUnitTypeId = Constants.UNIT_N0BC_CONTROL_POINT_DEFENDER_QUELTHALAS,
+        LearningDifficulty = FactionLearningDifficulty.Advanced,
         IntroText = @"You are playing as the power-hungry |cffff0000Sunfury|r.
 
 You begin in Netherstorm, your first mission is to build three biodomes in the green areas protected by a bubble.

--- a/src/WarcraftLegacies.Source/Setup/FactionSetup/ZandalarSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/FactionSetup/ZandalarSetup.cs
@@ -1,5 +1,6 @@
 ﻿using MacroTools;
 using MacroTools.Extensions;
+using MacroTools.FactionChoices;
 using MacroTools.FactionSystem;
 using WCSharp.Shared.Data;
 using static War3Api.Common;
@@ -20,6 +21,7 @@ namespace WarcraftLegacies.Source.Setup.FactionSetup
         ControlPointDefenderUnitTypeId = Constants.UNIT_H0C1_CONTROL_POINT_DEFENDER_ZANDALAR,
         StartingCameraPosition = Regions.TrollStartPos.Center,
         StartingUnits = Regions.TrollStartPos.PrepareUnitsForRescue(RescuePreparationMode.Invulnerable),
+        LearningDifficulty = FactionLearningDifficulty.Basic,
         IntroText = @"You are playing as the mighty |cffe1946cZandalari Empire|r.
 
 You start off at the southern coast of Tanaris, seperated from your allies. Raise an army and deal with the rogue Trolls in Zul'Farrak.

--- a/src/WarcraftLegacies.Source/Setup/GameSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/GameSetup.cs
@@ -46,9 +46,7 @@ namespace WarcraftLegacies.Source.Setup
       AllFactionSetup.Setup(preplacedUnitSystem, artifactSetup, allLegendSetup);
       SharedFactionConfigSetup.Setup();
       PlayerSetup.Setup();
-      new FactionChoiceDialogPresenter(GoblinSetup.Goblin, ZandalarSetup.Zandalar).Run(Player(8));
-      new FactionChoiceDialogPresenter(IllidariSetup.Illidari, SunfurySetup.Sunfury).Run(Player(15));
-      new FactionChoiceDialogPresenter(DalaranSetup.Dalaran, GilneasSetup.Gilneas).Run(Player(7));
+      FactionChoiceDialogSetup.Setup();
       NeutralHostileSetup.Setup();
       AllQuestSetup.Setup(preplacedUnitSystem, artifactSetup, allLegendSetup);
       ObserverSetup.Setup(new[] { Player(21) });


### PR DESCRIPTION
As can be seen below, Goblins are designated as Advanced while Zandalar is Basic. This distinction applies to all 3 Faction selections. Dalaran and Illidari are Basic, while Gilneas and Sunfury are Advanced. These designations can be changed easily.
![image](https://github.com/AzerothWarsLR/WarcraftLegacies/assets/8995690/c03f9651-0f8c-46d7-89a9-183314f06dc6)