### PR TITLE
Fixed Slow Poison tooltip inaccuracies

### DIFF
--- a/mapdata/WarcraftLegacies/AbilityData/Core/1462972737.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Core/1462972737.json
@@ -98,7 +98,7 @@
       "Pointer": 3,
       "Id": 862941267,
       "Type": 2,
-      "Value": 0.4
+      "Value": 0.35
     },
     {
       "Level": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/Skin/1279930433.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Skin/1279930433.json
@@ -48,7 +48,7 @@
       "Level": 1,
       "Id": 828536161,
       "Type": 3,
-      "Value": "A poison attack that deals \u003CAspo,DataA1\u003E damage per second, and reduces an enemy units attack by \u003CAspo,DataC1,%\u003E% for \u003CAspo,Dur1\u003E seconds."
+      "Value": "A poison attack that deals \u003CA0JL,DataA1\u003E damage per second, and reduces an enemy units attack by \u003CA0JL,DataC1,%\u003E% for \u003CA0JL,Dur1\u003E seconds."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/Skin/1462972737.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Skin/1462972737.json
@@ -18,13 +18,13 @@
       "Level": 1,
       "Id": 828536161,
       "Type": 3,
-      "Value": "A poison attack that deals \u003CA0JL:aspo,DataA1\u003E damage per second, and slows the target enemy\u0027s movement by \u003CA0JL:aspo,DataB1,%\u003E% and attack by \u003CA0JL:aspo,DataC1,%\u003E% for \u003CA0JL:aspo,Dur1\u003E seconds."
+      "Value": "A poison attack that deals \u003CA13W,DataA1\u003E damage per second, and slows the target enemy\u0027s movement by \u003CA13W,DataB1,%\u003E% and attack by \u003CA13W,DataC1,%\u003E% for \u003CA13W,Dur1\u003E seconds."
     },
     {
       "Level": 2,
       "Id": 828536161,
       "Type": 3,
-      "Value": "A poison attack that deals \u003CA0JL:aspo,DataA2\u003E damage per second, and slows the target enemy\u0027s movement by \u003CA0JL:aspo,DataB2,%\u003E% and attack by \u003CA0JL:aspo,DataC2,%\u003E% for \u003CA0JL:aspo,Dur2\u003E seconds."
+      "Value": "A poison attack that deals \u003CA13W,DataA2\u003E damage per second, and slows the target enemy\u0027s movement by \u003CA13W,DataB2,%\u003E% and attack by \u003CA13W,DataC2,%\u003E% for \u003CA13W,Dur2\u003E seconds."
     },
     {
       "Level": 2,
@@ -42,7 +42,7 @@
       "Level": 3,
       "Id": 828536161,
       "Type": 3,
-      "Value": "A poison attack that deals \u003CA0JL:aspo,DataA3\u003E damage per second, and slows the target enemy\u0027s movement by \u003CA0JL:aspo,DataB3,%\u003E% and attack by \u003CA0JL:aspo,DataC3,%\u003E% for \u003CA0JL:aspo,Dur3\u003E seconds."
+      "Value": "A poison attack that deals \u003CA13W,DataA3\u003E damage per second, and slows the target enemy\u0027s movement by \u003CA13W,DataB3,%\u003E% and attack by \u003CA13W,DataC3,%\u003E% for \u003CA13W,Dur3\u003E seconds."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/UpgradeData/Skin/926167122.json
+++ b/mapdata/WarcraftLegacies/UpgradeData/Skin/926167122.json
@@ -9,7 +9,7 @@
       "Level": 1,
       "Id": 828536167,
       "Type": 3,
-      "Value": "Improves Dryads\u0027 Slow Poison by increasing its movement speed reduction to \u003CA0JL,DataB2,%\u003E%, attack speed reduction to \u003CA0JL,DataC2,%\u003E%, and duration to \u003CA0JL,Dur2\u003E seconds."
+      "Value": "Improves Dryads\u0027 Slow Poison by increasing its movement speed reduction to \u003CA13W,DataB2,%\u003E%, attack speed reduction to \u003CA13W,DataC2,%\u003E%, and duration to \u003CA13W,Dur2\u003E seconds."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/UpgradeData/Skin/942944338.json
+++ b/mapdata/WarcraftLegacies/UpgradeData/Skin/942944338.json
@@ -9,7 +9,7 @@
       "Level": 1,
       "Id": 828536167,
       "Type": 3,
-      "Value": "Improves Dryads\u0027 Slow Poison by increasing its damage dealt per second to \u003CA0JL,DataA3\u003E and duration to \u003CA0JL,Dur3\u003E seconds."
+      "Value": "Improves Dryads\u0027 Slow Poison by increasing its damage dealt per second to \u003CA13W,DataA3\u003E and duration to \u003CA13W,Dur3\u003E seconds."
     },
     {
       "Level": 1,


### PR DESCRIPTION
- Dryad Slow Poison tooltip shows the correct values
- Both Dryad Slow Poison upgrades show the correct values
- Crypt Fiend Slow Poison shows the correct values
- Dryad Slow Poison level 3 attack speed reduction 40% --> 35% _(this accurately reflects the tooltip of the relevant research, which does not mention an attack speed reduction increase)_