### PR TITLE
Technopig/BookOfMedivhQuestFix

### DIFF
--- a/src/MacroTools/Extensions/PlayerExtensions.cs
+++ b/src/MacroTools/Extensions/PlayerExtensions.cs
@@ -74,7 +74,7 @@ namespace MacroTools.Extensions
     public static Faction? GetFaction(this player player) => PlayerData.ByHandle(player).Faction;
 
     /// <summary>Sets the player's <see cref="Faction"/>.</summary>
-    public static void SetFaction(this player player, Faction? faction) => PlayerData.ByHandle(player).Faction = faction;
+    public static void SetFaction(this player player, Faction faction) => PlayerData.ByHandle(player).Faction = faction;
 
     /// <summary>Returns the player's gold income, including any bonuses.</summary>
     public static float GetTotalIncome(this player player) => PlayerData.ByHandle(player).TotalIncome;

--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -285,13 +285,11 @@ namespace MacroTools.FactionSystem
 
       if (Player != null)
       {
-        var defeatedPlayer = Player;
-        FogModifierStart(CreateFogModifierRect(defeatedPlayer, FOG_OF_WAR_VISIBLE,
+        FogModifierStart(CreateFogModifierRect(Player, FOG_OF_WAR_VISIBLE,
           Rectangle.WorldBounds.Rect, false, false));
-        RemovePlayer(defeatedPlayer, PLAYER_GAME_RESULT_DEFEAT);
-        SetPlayerState(defeatedPlayer, PLAYER_STATE_OBSERVER, 1);
-        defeatedPlayer.SetFaction(null);
-        PlayerDistributor.DistributePlayer(defeatedPlayer);
+        RemovePlayer(Player, PLAYER_GAME_RESULT_DEFEAT);
+        SetPlayerState(Player, PLAYER_STATE_OBSERVER, 1);
+        PlayerDistributor.DistributePlayer(Player);
         RemoveGoldMines();
       }
 

--- a/src/MacroTools/FactionSystem/PlayerDistributor.cs
+++ b/src/MacroTools/FactionSystem/PlayerDistributor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using MacroTools.Extensions;
 using MacroTools.LegendSystem;


### PR DESCRIPTION
Defeated players are now removed after there units are killed and removed. This was changed to prevent a bug where The Book of Medivh quest would fail for all players if any player was defeated/left the game.

Testing done. 
Book of Medivh quest no longer fails when a player is defeated or leaves/is kicked from the game. 
Resources split evenly among the team when a player is removed as intended. 