### PR TITLE
Introduce TryGetFactionByName on FactionManager to handle nulls more easily

### DIFF
--- a/src/MacroTools/Cheats/CheatControl.cs
+++ b/src/MacroTools/Cheats/CheatControl.cs
@@ -59,10 +59,9 @@ namespace MacroTools.Cheats
         return $"{givesOrTakes} control of all players.";
       }
 
-      var target = FactionManager.GetFactionByName(parameters[0]);
-      if (target == null)
-        return $"{parameters[0]} is not a valid faction.";
-
+      if (!FactionManager.TryGetFactionByName(parameters[0], out var target))
+        return $"There is no faction named {parameters[0]}.";
+      
       if (target.Player == null)
         return $"Nobody is playing {target.ColoredName}.";
 

--- a/src/MacroTools/Cheats/CheatFaction.cs
+++ b/src/MacroTools/Cheats/CheatFaction.cs
@@ -26,16 +26,11 @@ namespace MacroTools.Cheats
     /// <inheritdoc />
     public override string Execute(player cheater, params string[] parameters)
     {
-      if (!FactionManager.FactionWithNameExists(parameters[0]))
+      if (!FactionManager.TryGetFactionByName(parameters[0], out var f))
         return $"There is no registered {nameof(Faction)} with the name {parameters[0]}.";
-
-      var f = FactionManager.GetFactionByName(parameters[0]);
-      if (f != null)
-      {
-        PlayerData.ByHandle(GetTriggerPlayer()).Faction = f;
-        return $"Successfully changed faction to {f.Name}.";
-      }
-      return $"Failed changing faction to {parameters[0]}";
+      
+      PlayerData.ByHandle(GetTriggerPlayer()).Faction = f;
+      return $"Successfully changed faction to {f.Name}.";
     }
   }
 }

--- a/src/MacroTools/Cheats/CheatKick.cs
+++ b/src/MacroTools/Cheats/CheatKick.cs
@@ -28,9 +28,8 @@ namespace MacroTools.Cheats
     {
       try
       {
-        var faction = FactionManager.GetFactionByName(parameters[0]);
-        if (faction == null)
-          return $"There is no registered {nameof(Faction)} with the name {parameters[0]}.";
+        if (!FactionManager.TryGetFactionByName(parameters[0], out var faction))
+          return $"There is no faction named {parameters[0]}.";
         
         faction.Defeat();
         return $"Kicking {nameof(Faction)} {faction.Name}.";

--- a/src/MacroTools/Cheats/CheatQuestProgress.cs
+++ b/src/MacroTools/Cheats/CheatQuestProgress.cs
@@ -47,9 +47,8 @@ namespace MacroTools.Cheats
       }
       else
       {
-        faction = FactionManager.GetFactionByName(parameters[1]);
-        if (faction == null) 
-          return $"{parameters[1]} is not a valid {nameof(Faction)}.";
+        if (!FactionManager.TryGetFactionByName(parameters[1], out faction))
+          return $"There is no faction named {parameters[0]}.";
       }
       
       var quest = faction.GetQuestByTitle(parameters[0]);

--- a/src/MacroTools/Cheats/CheatShowQuestNames.cs
+++ b/src/MacroTools/Cheats/CheatShowQuestNames.cs
@@ -26,11 +26,14 @@ namespace MacroTools.Cheats
     /// <inheritdoc />
     public override string Execute(player cheater, params string[] parameters)
     {
-      var quests = FactionManager.GetFactionByName(parameters[0])?.GetAllQuests();
+      if (!FactionManager.TryGetFactionByName(parameters[0], out var faction))
+        return $"There is no faction named {parameters[0]}.";
+      
+      var quests = faction.GetAllQuests();
       var message = $"Attempting to display all quests names of faction {parameters[0]}.\n";
-      if (quests != null)
-        foreach (var quest in quests)
-          message += $"Quest name: {quest.Title}\n";
+
+      foreach (var quest in quests)
+        message += $"Quest name: {quest.Title}\n";
       return message;
     }
   }

--- a/src/MacroTools/Cheats/CheatTeam.cs
+++ b/src/MacroTools/Cheats/CheatTeam.cs
@@ -25,9 +25,8 @@ namespace MacroTools.Cheats
     /// <inheritdoc />
     public override string Execute(player cheater, params string[] parameters)
     {
-      var faction = FactionManager.GetFactionByName(parameters[0]);
-      if (faction == null)
-        return $"You must specify a valid {nameof(Faction)} name as the first parameter.";
+      if (!FactionManager.TryGetFactionByName(parameters[0], out var faction))
+        return $"There is no faction named {parameters[0]}.";
       
       if (faction.Player == null)
         return $"The specified {nameof(Faction)} is not occupied by a player and therefore cannot have a {nameof(Team)}.";

--- a/src/MacroTools/Commands/GiveGold.cs
+++ b/src/MacroTools/Commands/GiveGold.cs
@@ -28,8 +28,7 @@ namespace MacroTools.Commands
     /// <inheritdoc />
     public override string Execute(player cheater, params string[] parameters)
     {
-      var targetFaction = FactionManager.GetFactionByName(parameters[0]);
-      if (targetFaction == null) 
+      if (!FactionManager.TryGetFactionByName(parameters[0], out var targetFaction))
         return $"There is no faction named {parameters[0]}.";
 
       if (targetFaction.Player == null)

--- a/src/MacroTools/Commands/Share.cs
+++ b/src/MacroTools/Commands/Share.cs
@@ -37,11 +37,10 @@ namespace MacroTools.Commands
           }
         }
 
-        return $"Shared control with all factions on your team.";
+        return "Shared control with all factions on your team.";
       }
 
-      var targetFaction = FactionManager.GetFactionByName(parameters[0]);
-      if (targetFaction == null)
+      if (!FactionManager.TryGetFactionByName(parameters[0], out var targetFaction))
         return $"There is no faction named {parameters[0]}.";
 
       if (targetFaction.Player == null)
@@ -54,6 +53,5 @@ namespace MacroTools.Commands
 
       return $"Shared control with {targetFaction.Name}.";
     }
-
   }
 }

--- a/src/MacroTools/FactionSystem/FactionManager.cs
+++ b/src/MacroTools/FactionSystem/FactionManager.cs
@@ -78,18 +78,15 @@ namespace MacroTools.FactionSystem
     public static bool TryGetTeamByName(string teamName, [NotNullWhen(true)] out Team? team) =>
       TeamsByName.TryGetValue(teamName.ToLower(), out team);
 
-    public static bool FactionWithNameExists(string name)
-    {
-      return FactionsByName.ContainsKey(name.ToLower());
-    }
-
     /// <summary>
-    /// Returns the <see cref="Faction"/> with the specified name if one exists.
-    /// Returns null otherwise.
+    /// Outputs the registered <see cref="Faction"/> with the specified name.
     /// </summary>
-    public static Faction? GetFactionByName(string name) => 
-      FactionsByName.TryGetValue(name.ToLower(), out var faction) ? faction : null;
-    
+    /// <param name="factionName">The name of the faction.</param>
+    /// <param name="faction">The faction with the specified name.</param>
+    /// <returns>Returns true if a faction with the specified name exists.</returns>
+    public static bool TryGetFactionByName(string factionName, [NotNullWhen(true)] out Faction? faction) => 
+      FactionsByName.TryGetValue(factionName.ToLower(), out faction);
+
     /// <summary>
     /// Returns true if a <see cref="Faction"/> with the specified type exists.
     /// </summary>
@@ -99,11 +96,6 @@ namespace MacroTools.FactionSystem
       faction = FactionsByName.Values.FirstOrDefault(x => x.GetType() == typeof(T)) as T;
       return faction != null;
     }
-
-    /// <summary>
-    /// Returns true if a <see cref="Faction"/> with the specified type exists.
-    /// </summary>
-    public static bool FactionOfTypeExists(Type factionType) => AllFactions.Any(x => x.GetType() == factionType);
 
     /// <summary>
     ///   Registers a <see cref="Faction" /> to the <see cref="FactionManager" />,
@@ -158,5 +150,10 @@ namespace MacroTools.FactionSystem
       foreach (var initializer in dependentInitializers)
         initializer.Execute();
     }
+    
+    /// <summary>
+    /// Returns true if a <see cref="Faction"/> with the specified type exists.
+    /// </summary>
+    private static bool FactionOfTypeExists(Type factionType) => AllFactions.Any(x => x.GetType() == factionType);
   }
 }

--- a/src/WarcraftLegacies.Source/Commands/InviteCommand.cs
+++ b/src/WarcraftLegacies.Source/Commands/InviteCommand.cs
@@ -19,13 +19,11 @@ namespace WarcraftLegacies.Source.Commands
       var content = SubString(enteredString, StringLength(Command), StringLength(enteredString));
       content = StringCase(content, false);
 
-      if (!FactionManager.FactionWithNameExists(content))
+      if (!FactionManager.TryGetFactionByName(content, out var targetFaction))
       {
         DisplayTextToPlayer(triggerPlayer, 0, 0, $"There is no Faction with the name {content}.");
         return;
       }
-
-      var targetFaction = FactionManager.GetFactionByName(content);
 
       if (triggerPlayer.GetFaction() == targetFaction)
       {

--- a/src/WarcraftLegacies.Source/Commands/UninviteCommand.cs
+++ b/src/WarcraftLegacies.Source/Commands/UninviteCommand.cs
@@ -19,9 +19,8 @@ namespace WarcraftLegacies.Source.Commands
       var content = SubString(enteredString, StringLength(Command), StringLength(enteredString));
       content = StringCase(content, false);
 
-      if (FactionManager.FactionWithNameExists(content))
+      if (FactionManager.TryGetFactionByName(content, out var targetFaction))
       {
-        var targetFaction = FactionManager.GetFactionByName(content);
         if (targetFaction.Player != null)
           triggerPlayer.GetTeam()?.Uninvite(targetFaction.Player);
         else


### PR DESCRIPTION
The old GetFactionByName method could return null which then had to be handled. Using the Try pattern instead means the consumer only needs to deal with the Faction if they actually get one.