### PR TITLE
Technopig/Sunfury and Scarlet fix

### DIFF
--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -281,7 +281,13 @@ namespace MacroTools.FactionSystem
     ///   Returns the maximum number of times the Faction can train a unit, build a building, or research a research.
     /// </summary>
     /// <param name="whichObject">The object ID of a unit, building, or research.</param>
-    public int GetObjectLimit(int whichObject) => _objectLimits.GetValueOrDefault(whichObject, 0);
+    public int GetObjectLimit(int whichObject)
+    {
+      if (_objectLimits.TryGetValue(whichObject, out var limit))
+        return limit;
+
+      return 0; 
+    }
 
     /// <summary>
     /// Provides the unit type belonging to the provided <see cref="UnitCategory"/> for this faction, if any.

--- a/src/WarcraftLegacies.Shared/FactionObjectLimits/IronforgeObjectInfo.cs
+++ b/src/WarcraftLegacies.Shared/FactionObjectLimits/IronforgeObjectInfo.cs
@@ -12,8 +12,7 @@ namespace WarcraftLegacies.Shared.FactionObjectLimits
       yield return new("h07E", Unlimited); //Town Hall
       yield return new("h07F", Unlimited); //Keep
       yield return new("h07G", Unlimited); //Castle
-      yield return new("h02P", Unlimited); //Farm  (Dwarven)
-      yield return new("h01S", Unlimited); //Tavern
+      yield return new(UNIT_H01S_TAVERN_IRONFORGE_FARM, Unlimited, UnitCategory.Farm);
       yield return new("h07B", Unlimited); //Altar of Kings
       yield return new("h07C", Unlimited); //Barracks
       yield return new("hlum", Unlimited); //Lumber Mill


### PR DESCRIPTION
- Replaced `GetValueOrDefault` method with `TryGetValue` which better transcribes to Lua, this fixes an issue where the player could not peform the Sunfury choice as Lordaerons ObjectData was returning a Null value. 

- Updated Ironforge's Constant library as some outdated FourCC constants were conflicting with the newer OID's, as a result the Sunfury faction choice did not work correctly. 


Closes 
#3278 
#3274 