### PR TITLE
Technopig/Exodar Slipstream portal fix

### DIFF
--- a/mapdata/WarcraftLegacies/Regions/ExodarBaseUnlock.json
+++ b/mapdata/WarcraftLegacies/Regions/ExodarBaseUnlock.json
@@ -1,8 +1,8 @@
 {
-  "Left": -24544,
-  "Bottom": 5792,
-  "Right": -21216,
-  "Top": 9056,
+  "Left": -24608,
+  "Bottom": 5632,
+  "Right": -21280,
+  "Top": 8896,
   "Name": "ExodarBaseUnlock",
   "CreationNumber": 7,
   "AmbientSound": "",

--- a/mapdata/WarcraftLegacies/Regions/Netherstorm.json
+++ b/mapdata/WarcraftLegacies/Regions/Netherstorm.json
@@ -1,8 +1,8 @@
 {
-  "Left": -544,
-  "Bottom": -23712,
-  "Right": 3680,
-  "Top": -18528,
+  "Left": -736,
+  "Bottom": -23616,
+  "Right": 3488,
+  "Top": -18432,
   "Name": "Netherstorm",
   "CreationNumber": 150,
   "AmbientSound": "",

--- a/mapdata/WarcraftLegacies/Regions/SlipstreamArgusOrigin.json
+++ b/mapdata/WarcraftLegacies/Regions/SlipstreamArgusOrigin.json
@@ -1,0 +1,15 @@
+{
+  "Left": -23104,
+  "Bottom": 7712,
+  "Right": -22592,
+  "Top": 7872,
+  "Name": "SlipstreamArgusOrigin",
+  "CreationNumber": 198,
+  "AmbientSound": "",
+  "Color": {
+    "A": 255,
+    "R": 128,
+    "G": 128,
+    "B": 255
+  }
+}

--- a/mapdata/WarcraftLegacies/Regions/SlipstreamArgusTarget.json
+++ b/mapdata/WarcraftLegacies/Regions/SlipstreamArgusTarget.json
@@ -1,0 +1,15 @@
+{
+  "Left": 21408,
+  "Bottom": -27200,
+  "Right": 22080,
+  "Top": -26656,
+  "Name": "SlipstreamArgusTarget",
+  "CreationNumber": 199,
+  "AmbientSound": "",
+  "Color": {
+    "A": 255,
+    "R": 128,
+    "G": 128,
+    "B": 255
+  }
+}

--- a/mapdata/WarcraftLegacies/Regions/SlipstreamTempestOrigin.json
+++ b/mapdata/WarcraftLegacies/Regions/SlipstreamTempestOrigin.json
@@ -1,0 +1,15 @@
+{
+  "Left": -22304,
+  "Bottom": 6816,
+  "Right": -22112,
+  "Top": 7392,
+  "Name": "SlipstreamTempestOrigin",
+  "CreationNumber": 186,
+  "AmbientSound": "",
+  "Color": {
+    "A": 255,
+    "R": 128,
+    "G": 128,
+    "B": 255
+  }
+}

--- a/mapdata/WarcraftLegacies/Regions/SlipstreamTempestTarget.json
+++ b/mapdata/WarcraftLegacies/Regions/SlipstreamTempestTarget.json
@@ -1,0 +1,15 @@
+{
+  "Left": 2752,
+  "Bottom": -21920,
+  "Right": 3200,
+  "Top": -21504,
+  "Name": "SlipstreamTempestTarget",
+  "CreationNumber": 190,
+  "AmbientSound": "",
+  "Color": {
+    "A": 255,
+    "R": 128,
+    "G": 128,
+    "B": 255
+  }
+}

--- a/mapdata/WarcraftLegacies/war3mapMap.blp
+++ b/mapdata/WarcraftLegacies/war3mapMap.blp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a006ce6600ecc10b588126b63d1cc7c904aa604f441256f433d6a5057ccf056e
-size 18897
+oid sha256:0950ccf4004a23a03900c5e6b2234d77c83c2f60655aea8c930208f4ee8b298b
+size 18924

--- a/src/WarcraftLegacies.Source/Regions.cs
+++ b/src/WarcraftLegacies.Source/Regions.cs
@@ -105,7 +105,7 @@ public static class Regions
 	public static Rectangle ElementalRealm { get; set; } = new Rectangle(-18016f, -22848f, -8480f, -20320f);
 	public static Rectangle ElwinForestAmbient { get; set; } = new Rectangle(8704f, -14816f, 13376f, -12672f);
 	public static Rectangle EnKilahUnlock { get; set; } = new Rectangle(-6016f, 18176f, -4832f, 18848f);
-	public static Rectangle ExodarBaseUnlock { get; set; } = new Rectangle(-24544f, 5792f, -21216f, 9056f);
+	public static Rectangle ExodarBaseUnlock { get; set; } = new Rectangle(-24608f, 5632f, -21280f, 8896f);
 	public static Rectangle Far_Eastern_Northrend { get; set; } = new Rectangle(4608f, 20064f, 7328f, 22944f);
 	public static Rectangle FeathermoonCreeps { get; set; } = new Rectangle(-22464f, -12128f, -18368f, -7584f);
 	public static Rectangle FeathermoonUnlock { get; set; } = new Rectangle(-21376f, -10272f, -19776f, -7840f);
@@ -204,7 +204,7 @@ public static class Regions
 	public static Rectangle MountHyjal { get; set; } = new Rectangle(-11328f, 9856f, -8832f, 11264f);
 	public static Rectangle Nazjatar { get; set; } = new Rectangle(-5792f, -3680f, -5024f, -2752f);
 	public static Rectangle NethergardeUnlock { get; set; } = new Rectangle(16576f, -18400f, 18688f, -16960f);
-	public static Rectangle Netherstorm { get; set; } = new Rectangle(-544f, -23712f, 3680f, -18528f);
+	public static Rectangle Netherstorm { get; set; } = new Rectangle(-736f, -23616f, 3488f, -18432f);
 	public static Rectangle Northern_Kali_Ships { get; set; } = new Rectangle(-17760f, -800f, -9120f, 9376f);
 	public static Rectangle Northrend_Ambiance { get; set; } = new Rectangle(-10688f, 13120f, 8608f, 24736f);
 	public static Rectangle Northrend_Blocker_1 { get; set; } = new Rectangle(5376f, 13568f, 6016f, 13952f);
@@ -364,5 +364,9 @@ public static class Regions
 	public static Rectangle ZulAman_trolls { get; set; } = new Rectangle(20288f, 11648f, 22848f, 17440f);
 	public static Rectangle Zulfarrak { get; set; } = new Rectangle(-12352f, -14272f, -10528f, -12064f);
 	public static Rectangle ZulfarrakAmbient { get; set; } = new Rectangle(-5952f, -17216f, 2944f, -10368f);
+	public static Rectangle SlipstreamTempestOrigin { get; set; } = new Rectangle(-22304f, 6816f, -22112f, 7392f);
+	public static Rectangle SlipstreamTempestTarget { get; set; } = new Rectangle(2752f, -21920f, 3200f, -21504f);
+	public static Rectangle SlipstreamArgusOrigin { get; set; } = new Rectangle(-23104f, 7712f, -22592f, 7872f);
+	public static Rectangle SlipstreamArgusTarget { get; set; } = new Rectangle(21408f, -27200f, 22080f, -26656f);
 
 }

--- a/src/WarcraftLegacies.Source/Setup/Spells/DraeneiSpellSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/Spells/DraeneiSpellSetup.cs
@@ -6,53 +6,48 @@ using WarcraftLegacies.Source.Spells.MassiveAttack;
 using WarcraftLegacies.Source.Spells.Slipstream;
 using WCSharp.Shared.Data;
 
+
 namespace WarcraftLegacies.Source.Setup.Spells
 {
-  /// <summary>
-  /// Responsible for setting up all Draenei <see cref="Spell"/>s.
-  /// </summary>
   public static class DraeneiSpellSetup
   {
-    /// <summary>
-    /// Sets up all Draenei <see cref="Spell"/>s.
-    /// </summary>
     public static void Setup()
     {
-      var slipstreamOrigin = new Point(-22259.9f, 7104.2f);
-      
-      //Azuremyst
-      SpellSystem.Register(new SlipstreamSpellSpecificOriginAndDestination(ABILITY_A0P9_PORTAL_TO_AZUREMYST_DRAENEI)
+      Point slipstreamTempestOriginPoint = Regions.SlipstreamTempestOrigin.GetRandomPoint();
+      Point slipstreamTempestTargetPoint = Regions.SlipstreamTempestTarget.GetRandomPoint();
+      Point slipstreamArgusOriginPoint = Regions.SlipstreamArgusOrigin.GetRandomPoint();
+      Point slipstreamArgusTargetPoint = Regions.SlipstreamArgusTarget.GetRandomPoint();
+      Point slipstreamAzuremystTargetPoint = new Point(-20940, 10412); 
+
+     SpellSystem.Register(new SlipstreamSpellSpecificOriginAndDestination(ABILITY_A0P9_PORTAL_TO_AZUREMYST_DRAENEI)
       {
         PortalUnitTypeId = UNIT_N0D9_SLIPSTREAM_PORTAL_STORMWIND_KHADGAR,
         OpeningDelay = 20,
         ClosingDelay = 10,
-        OriginLocation = slipstreamOrigin,
-        TargetLocation = new Point(-20940, 10412),
+        OriginLocation = slipstreamArgusOriginPoint,
+        TargetLocation = slipstreamAzuremystTargetPoint,
         Color = new Color(155, 250, 50, 255)
       });
-
-      //Argus
       SpellSystem.Register(new SlipstreamSpellSpecificOriginAndDestination(ABILITY_A0RB_PORTAL_TO_ARGUS_DRAENEI)
       {
         PortalUnitTypeId = UNIT_N0D9_SLIPSTREAM_PORTAL_STORMWIND_KHADGAR,
         OpeningDelay = 20,
         ClosingDelay = 10,
-        OriginLocation = slipstreamOrigin,
-        TargetLocation = new Point(22010, -26816),
+        OriginLocation = slipstreamArgusOriginPoint,
+        TargetLocation = slipstreamArgusTargetPoint,
         Color = new Color(255, 50, 50, 255)
       });
 
-      //Outland
       SpellSystem.Register(new SlipstreamSpellSpecificOriginAndDestination(ABILITY_A0SR_PORTAL_TO_TEMPEST_KEEP_DRAENEI)
       {
         PortalUnitTypeId = UNIT_N0D9_SLIPSTREAM_PORTAL_STORMWIND_KHADGAR,
         OpeningDelay = 20,
         ClosingDelay = 10,
-        OriginLocation = slipstreamOrigin,
-        TargetLocation = new Point(2943, -21644),
+        OriginLocation = slipstreamTempestOriginPoint,
+        TargetLocation = slipstreamTempestTargetPoint,
         Color = new Color(55, 50, 250, 255)
       });
-      
+
       PassiveAbilityManager.Register(new MassiveAttackAbility(UNIT_N0CX_LIGHTFORGED_WARFRAME_DRAENEI)
       {
         AttackDamagePercentage = 0.3f,


### PR DESCRIPTION
Refactored Slipstream portals to use a random point in a region rather than an exact point .
This fixes a bug where Exodar's Slipstream portals would not work after being cast more than once.

closes #3283 