### PR TITLE
Technopig/DynamicFactionColours 

### DIFF
--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -86,23 +86,10 @@ namespace MacroTools.FactionSystem
       Id = _highestId + 1;
       _highestId = Id;
 
-      
-      foreach (var color in colorPriority)
-      {
-        if (ColorManager.IsColorAvailable(color))
-        {
-          PlayerColor = color;
-          ColorManager.AssignColor(color);
-          PrefixCol = ColorManager.GetColorHexCode(color); 
-          break;
-        }
-      }
-
-      if (PlayerColor == null)
-      {
-        throw new InvalidOperationException($"No available colors could be assigned to faction {name}.");
-      }
+      PlayerColor = ColorManager.AssignPreferredColorOrFallback(colorPriority);
+      PrefixCol = ColorManager.GetColorHexCode(PlayerColor);
     }
+
 
 
     internal List<FactionDependentInitializer> FactionDependentInitializers { get; } = new();

--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -78,16 +78,32 @@ namespace MacroTools.FactionSystem
       });
     }
 
-    protected Faction(string name, playercolor playerColor, string prefixCol, string icon)
+    protected Faction(string name, playercolor[] colorPriority, string icon)
     {
       _name = name;
-      PlayerColor = playerColor;
-      PrefixCol = prefixCol;
       _icon = icon;
       FoodMaximum = FoodMaximumDefault;
       Id = _highestId + 1;
       _highestId = Id;
+
+      
+      foreach (var color in colorPriority)
+      {
+        if (ColorManager.IsColorAvailable(color))
+        {
+          PlayerColor = color;
+          ColorManager.AssignColor(color);
+          PrefixCol = ColorManager.GetColorHexCode(color); 
+          break;
+        }
+      }
+
+      if (PlayerColor == null)
+      {
+        throw new InvalidOperationException($"No available colors could be assigned to faction {name}.");
+      }
     }
+
 
     internal List<FactionDependentInitializer> FactionDependentInitializers { get; } = new();
 

--- a/src/MacroTools/FactionSystem/Faction.cs
+++ b/src/MacroTools/FactionSystem/Faction.cs
@@ -92,6 +92,8 @@ namespace MacroTools.FactionSystem
 
 
 
+
+
     internal List<FactionDependentInitializer> FactionDependentInitializers { get; } = new();
 
     /// <summary>A unique numerical identifier.</summary>
@@ -273,12 +275,19 @@ namespace MacroTools.FactionSystem
         SetPlayerState(Player, PLAYER_STATE_OBSERVER, 1);
         PlayerDistributor.DistributePlayer(Player);
         RemoveGoldMines();
+
+        if (PlayerColor != null)
+        {
+          ColorManager.ReleaseColor(PlayerColor);
+        }
       }
 
       ScoreStatus = ScoreStatus.Defeated;
+
       StatusChanged?.Invoke(this, this);
       ScoreStatusChanged?.Invoke(this, this);
     }
+
 
     /// <summary>
     ///   Returns the maximum number of times the Faction can train a unit, build a building, or research a research.

--- a/src/MacroTools/FactionSystem/FactionColorManager.cs
+++ b/src/MacroTools/FactionSystem/FactionColorManager.cs
@@ -83,11 +83,22 @@ namespace MacroTools.FactionSystem
       {
         ColorAvailability[color] = true;
       }
+      else
+      {
+        throw new InvalidOperationException($"Tried to release color {color} but it is not managed.");
+      }
     }
 
     public static string GetColorHexCode(Common.playercolor color)
     {
-      return ColorHexMap.ContainsKey(color) ? ColorHexMap[color] : "|cffffffff";
+      if (ColorHexMap.ContainsKey(color))
+      {
+        return ColorHexMap[color];
+      }
+      else
+      {
+        return "|cffffffff"; // Default to white
+      }
     }
 
     public static Common.playercolor GetFallbackColor()

--- a/src/MacroTools/FactionSystem/FactionColorManager.cs
+++ b/src/MacroTools/FactionSystem/FactionColorManager.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using War3Api;
+
+namespace MacroTools.FactionSystem
+{
+  public static class ColorManager
+  {
+    private static readonly Dictionary<Common.playercolor, bool> ColorAvailability = new();
+    private static readonly Dictionary<Common.playercolor, string> ColorHexMap = new();
+
+    static ColorManager()
+    {
+      ColorAvailability[Common.PLAYER_COLOR_RED] = true;
+      ColorAvailability[Common.PLAYER_COLOR_BLUE] = true;
+      ColorAvailability[Common.PLAYER_COLOR_CYAN] = true;
+      ColorAvailability[Common.PLAYER_COLOR_PURPLE] = true;
+      ColorAvailability[Common.PLAYER_COLOR_YELLOW] = true;
+      ColorAvailability[Common.PLAYER_COLOR_ORANGE] = true;
+      ColorAvailability[Common.PLAYER_COLOR_GREEN] = true;
+      ColorAvailability[Common.PLAYER_COLOR_PINK] = true;
+      ColorAvailability[Common.PLAYER_COLOR_LIGHT_GRAY] = true;
+      ColorAvailability[Common.PLAYER_COLOR_LIGHT_BLUE] = true;
+      ColorAvailability[Common.PLAYER_COLOR_AQUA] = true;
+      ColorAvailability[Common.PLAYER_COLOR_BROWN] = true;
+      ColorAvailability[Common.PLAYER_COLOR_MAROON] = true;
+      ColorAvailability[Common.PLAYER_COLOR_NAVY] = true;
+      ColorAvailability[Common.PLAYER_COLOR_TURQUOISE] = true;
+      ColorAvailability[Common.PLAYER_COLOR_VIOLET] = true;
+      ColorAvailability[Common.PLAYER_COLOR_WHEAT] = true;
+      ColorAvailability[Common.PLAYER_COLOR_PEACH] = true;
+      ColorAvailability[Common.PLAYER_COLOR_MINT] = true;
+      ColorAvailability[Common.PLAYER_COLOR_LAVENDER] = true;
+      ColorAvailability[Common.PLAYER_COLOR_COAL] = true;
+      ColorAvailability[Common.PLAYER_COLOR_EMERALD] = true;
+      ColorAvailability[Common.PLAYER_COLOR_PEANUT] = true;
+
+// UI colours etc 
+      ColorHexMap[Common.PLAYER_COLOR_RED] = "|cffff0303";
+      ColorHexMap[Common.PLAYER_COLOR_BLUE] = "|cff0042ff";
+      ColorHexMap[Common.PLAYER_COLOR_CYAN] = "|cff1be7ba";
+      ColorHexMap[Common.PLAYER_COLOR_PURPLE] = "|cff550081";
+      ColorHexMap[Common.PLAYER_COLOR_YELLOW] = "|cfffefc00";
+      ColorHexMap[Common.PLAYER_COLOR_ORANGE] = "|cfffe890d";
+      ColorHexMap[Common.PLAYER_COLOR_GREEN] = "|cff21bf00";
+      ColorHexMap[Common.PLAYER_COLOR_PINK] = "|cffe45caf";
+      ColorHexMap[Common.PLAYER_COLOR_LIGHT_GRAY] = "|cff939596";
+      ColorHexMap[Common.PLAYER_COLOR_LIGHT_BLUE] = "|cff7ebff1";
+      ColorHexMap[Common.PLAYER_COLOR_AQUA] = "|cff00ebff";
+      ColorHexMap[Common.PLAYER_COLOR_BROWN] = "|cff4f2b05";
+      ColorHexMap[Common.PLAYER_COLOR_MAROON] = "|cff9c0000";
+      ColorHexMap[Common.PLAYER_COLOR_NAVY] = "|cff0000c3";
+      ColorHexMap[Common.PLAYER_COLOR_TURQUOISE] = "|cff00ebff";
+      ColorHexMap[Common.PLAYER_COLOR_VIOLET] = "|cffbd00ff";
+      ColorHexMap[Common.PLAYER_COLOR_WHEAT] = "|cffecce87";
+      ColorHexMap[Common.PLAYER_COLOR_PEACH] = "|cfff7a58b";
+      ColorHexMap[Common.PLAYER_COLOR_MINT] = "|cffbfff81";
+      ColorHexMap[Common.PLAYER_COLOR_LAVENDER] = "|cffdbb8eb";
+      ColorHexMap[Common.PLAYER_COLOR_COAL] = "|cff4f5055";
+      ColorHexMap[Common.PLAYER_COLOR_EMERALD] = "|cff00781e";
+      ColorHexMap[Common.PLAYER_COLOR_PEANUT] = "|cffa56f34";
+    }
+
+    public static bool IsColorAvailable(Common.playercolor color)
+    {
+      return ColorAvailability.ContainsKey(color) && ColorAvailability[color];
+    }
+
+    public static void AssignColor(Common.playercolor color)
+    {
+      if (IsColorAvailable(color))
+      {
+        ColorAvailability[color] = false;
+      }
+      else
+      {
+        throw new InvalidOperationException($"Color {color} is already in use!");
+      }
+    }
+
+    public static void ReleaseColor(Common.playercolor color)
+    {
+      if (ColorAvailability.ContainsKey(color))
+      {
+        ColorAvailability[color] = true;
+      }
+    }
+
+    public static string GetColorHexCode(Common.playercolor color)
+    {
+      return ColorHexMap.ContainsKey(color) ? ColorHexMap[color] : "|cffffffff"; // Default to white if color not found
+    }
+  }
+}

--- a/src/MacroTools/FactionSystem/FactionColorManager.cs
+++ b/src/MacroTools/FactionSystem/FactionColorManager.cs
@@ -35,7 +35,6 @@ namespace MacroTools.FactionSystem
       ColorAvailability[Common.PLAYER_COLOR_EMERALD] = true;
       ColorAvailability[Common.PLAYER_COLOR_PEANUT] = true;
 
-// UI colours etc 
       ColorHexMap[Common.PLAYER_COLOR_RED] = "|cffff0303";
       ColorHexMap[Common.PLAYER_COLOR_BLUE] = "|cff0042ff";
       ColorHexMap[Common.PLAYER_COLOR_CYAN] = "|cff1be7ba";
@@ -88,7 +87,36 @@ namespace MacroTools.FactionSystem
 
     public static string GetColorHexCode(Common.playercolor color)
     {
-      return ColorHexMap.ContainsKey(color) ? ColorHexMap[color] : "|cffffffff"; // Default to white if color not found
+      return ColorHexMap.ContainsKey(color) ? ColorHexMap[color] : "|cffffffff";
+    }
+
+    public static Common.playercolor GetFallbackColor()
+    {
+      foreach (var kvp in ColorAvailability)
+      {
+        if (kvp.Value)
+        {
+          return kvp.Key;
+        }
+      }
+
+      throw new InvalidOperationException("No colors are available to assign.");
+    }
+
+    public static Common.playercolor AssignPreferredColorOrFallback(Common.playercolor[] preferredColors)
+    {
+      foreach (var color in preferredColors)
+      {
+        if (IsColorAvailable(color))
+        {
+          AssignColor(color);
+          return color;
+        }
+      }
+
+      var fallbackColor = GetFallbackColor();
+      AssignColor(fallbackColor);
+      return fallbackColor;
     }
   }
 }

--- a/src/TestMap.Source/Factions/SpaceMarines.cs
+++ b/src/TestMap.Source/Factions/SpaceMarines.cs
@@ -7,7 +7,7 @@ namespace TestMap.Source.Factions
   public sealed class SpaceMarines : Faction
   {
     /// <inheritdoc />
-    public SpaceMarines() : base("Space Marines", PLAYER_COLOR_EMERALD, "|cff00781e",
+    public SpaceMarines() : base("Space Marines", new[] { PLAYER_COLOR_LIGHT_BLUE, PLAYER_COLOR_AQUA, PLAYER_COLOR_PEACH},
       @"ReplaceableTextures\CommandButtons\BTNMarine.blp")
     {
       TraditionalTeam = TeamSetup.TeamAlliance;

--- a/src/WarcraftLegacies.Source/Factions/Ahnqiraj.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ahnqiraj.cs
@@ -27,7 +27,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly unit _gateAhnQiraj;
 
     /// <inheritdoc />
-    public Ahnqiraj(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup) : base("Ahn'qiraj", PLAYER_COLOR_WHEAT, "|cffaaa050",
+    public Ahnqiraj(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup) : base("Ahn'qiraj", new[] {PLAYER_COLOR_WHEAT, PLAYER_COLOR_PEACH, PLAYER_COLOR_LIGHT_GRAY},
       @"ReplaceableTextures\CommandButtons\BTNCthunIcon.blp")
     {
       _allLegendSetup = allLegendSetup;

--- a/src/WarcraftLegacies.Source/Factions/Ahnqiraj.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ahnqiraj.cs
@@ -35,13 +35,11 @@ namespace WarcraftLegacies.Source.Factions
       ControlPointDefenderUnitTypeId = UNIT_N0DW_CONTROL_POINT_DEFENDER_CTHUN_TOWER;
       TraditionalTeam = TeamSetup.OldGods;
       StartingGold = 200;
-      IntroText = @"You are playing as the C'thun and his Qiraji followers|r|r.
+      IntroText = $"You are playing as the {PrefixCol}C'thun and his Qiraji followers|r.\n\n" +
+                  "You start deep in the tunnels of Ahn'qiraj. You will need to awaken C'thun and free yourself from the Titan Guardians.\n\n" +
+                  "Then, quickly start making your move north, coordinate with your elemental ally to attack Kalimdor.\n\n" +
+                  "You do not possess boats, but your workers can burrow through water, use them to outmaneuver your enemies.";
 
-You start deep in the tunnels of Ahn'qiraj. You will need to awaken C'thun and free yourself from the Titan Guardians.
-
-Then, quickly start making your move north, coordinate with your elemental ally to attack Kalimdor.
-
-You do not possess boats, but your workers can burrow through water, use them to outmaneuver your enemies.";
       Nicknames = new List<string>
       {
         "aq",

--- a/src/WarcraftLegacies.Source/Factions/Bilgewater.cs
+++ b/src/WarcraftLegacies.Source/Factions/Bilgewater.cs
@@ -19,7 +19,7 @@ namespace WarcraftLegacies.Source.Factions
     private ArtifactSetup _artifactSetup;
 
     /// <inheritdoc />
-    public Bilgewater(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Bilgewater", PLAYER_COLOR_LIGHT_GRAY, "|cff808080",
+    public Bilgewater(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Bilgewater", new[] {PLAYER_COLOR_LIGHT_GRAY, PLAYER_COLOR_LIGHT_BLUE, PLAYER_COLOR_AQUA},
       @"ReplaceableTextures\CommandButtons\BTNHeroTinker.blp")
     {
       TraditionalTeam = TeamSetup.Horde;

--- a/src/WarcraftLegacies.Source/Factions/Bilgewater.cs
+++ b/src/WarcraftLegacies.Source/Factions/Bilgewater.cs
@@ -27,13 +27,11 @@ namespace WarcraftLegacies.Source.Factions
       _artifactSetup = artifactSetup;
       StartingGold = 200;
       ControlPointDefenderUnitTypeId = UNIT_O01C_CONTROL_POINT_DEFENDER_GOBLIN;
-      IntroText = @"You are playing as the industrious |cff808080Bilgewater Cartel|r.
+      IntroText = $"You are playing as the industrious {PrefixCol}Bilgewater Cartel|r.\n\n" +
+                  "You begin in Tanaris with a very small business venture. Expand onto Kalimdor to grow your trade empire.\n\n" +
+                  "Your advanced units require Oil to function. Use oil ships to find oil deposits in the Great Sea and build platforms on them.\n\n" +
+                  "The Trading Center in Kezan will unlock the ability to train Traders. Be sure to protect the Trading Center once you unlock it, as it will form the backbone of your Goblin Empire.";
 
-You begin in Tanaris with a very small business venture. Expand onto Kalimdor to grow your trade empire.
-
-Your advanced units require Oil to function. Use oil ships to find oil deposits in the Great Sea and build platforms on them.
-
-The Trading Center in Kezan will unlock the ability to train Traders. Be sure to protect the Trading Center once you unlock it, as it will form the backbone of your Goblin Empire.";
       GoldMines = new List<unit>
       {
         preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(-8615, -12869)), //Starting

--- a/src/WarcraftLegacies.Source/Factions/BlackEmpire.cs
+++ b/src/WarcraftLegacies.Source/Factions/BlackEmpire.cs
@@ -26,13 +26,11 @@ namespace WarcraftLegacies.Source.Factions
       ControlPointDefenderUnitTypeId = UNIT_N0DV_CONTROL_POINT_DEFENDER_BLACK_EMPIRE_TOWER;
       TraditionalTeam = TeamSetup.OldGods;
       StartingGold = 200;
-      IntroText = @"You are playing as the Black Empire of N'zoth|r|r.
+      IntroText = $"You are playing as the {PrefixCol}Black Empire of N'zoth|r.\n\n" +
+                  "You start in Nyalotha, restore the city to its glory by repelling the invaders from Azeroth.\n\n" +
+                  "Then, move onto Kalimdor with your allies. You will quickly run into the Sentinels.\n\n" +
+                  "Be sure to train Forsaken Ones, they are powerful units.";
 
-You start in Nyalotha, restore the city to it's glory by repelling the invaders from Azeroth.
-
-Then, move onto Kalimdor with your allies. You will quickly run into the Sentinels.
-
-Be sure to train Forsaken Ones, they are powerful units";
       Nicknames = new List<string>
       {
         "be",

--- a/src/WarcraftLegacies.Source/Factions/BlackEmpire.cs
+++ b/src/WarcraftLegacies.Source/Factions/BlackEmpire.cs
@@ -18,7 +18,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly PreplacedUnitSystem _preplacedUnitSystem;
 
     /// <inheritdoc />
-    public BlackEmpire(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup) : base("BlackEmpire", PLAYER_COLOR_MAROON, "|cff800000",
+    public BlackEmpire(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup) : base("BlackEmpire", new[] {PLAYER_COLOR_MAROON, PLAYER_COLOR_RED, PLAYER_COLOR_BROWN},
       @"ReplaceableTextures\CommandButtons\BTNNzothIcon.blp")
     {
       _allLegendSetup = allLegendSetup;

--- a/src/WarcraftLegacies.Source/Factions/Dalaran.cs
+++ b/src/WarcraftLegacies.Source/Factions/Dalaran.cs
@@ -27,7 +27,7 @@ namespace WarcraftLegacies.Source.Factions
 
     /// <inheritdoc />
     public Dalaran(PreplacedUnitSystem preplacedUnitSystem, ArtifactSetup artifactSetup, AllLegendSetup allLegendSetup)
-      : base("Dalaran", PLAYER_COLOR_PINK, "|c00e55bb0", @"ReplaceableTextures\CommandButtons\BTNJaina.blp")
+      : base("Dalaran", new[] {PLAYER_COLOR_PINK, PLAYER_COLOR_PEACH, PLAYER_COLOR_RED}, @"ReplaceableTextures\CommandButtons\BTNJaina.blp")
     {
       TraditionalTeam = TeamSetup.NorthAlliance;
       _artifactSetup = artifactSetup;

--- a/src/WarcraftLegacies.Source/Factions/Dalaran.cs
+++ b/src/WarcraftLegacies.Source/Factions/Dalaran.cs
@@ -43,13 +43,11 @@ namespace WarcraftLegacies.Source.Factions
       StartingGold = 200;
       CinematicMusic = "SadMystery";
       ControlPointDefenderUnitTypeId = UNIT_N00N_CONTROL_POINT_DEFENDER_DALARAN;
-      IntroText = @"You are playing the wise |cffff8080Council of Dalaran|r.
+      IntroText = $"You are playing the wise {PrefixCol}Council of Dalaran|r.\n\n" +
+                  "You begin in the Hillsbrad Foothills, separated from the main forces of Dalaran. To unlock Dalaran, you must capture Shadowfang Keep, which has been encircled by monsters.\n\n" +
+                  "Once your territory is secured, you will need to prepare for the Plague of Undeath and the invasion of the Burning Legion. Lordaeron will surely need your help.\n\n" +
+                  "Your mages are the finest in Azeroth. Be sure to utilize them alongside your heroes to turn the tide of battle.";
 
-You begin in the Hillsbrad Foothills, separated from the main forces of Dalaran. To unlock Dalaran you must capture Shadowfang Keep, which have been encircled by monsters.
-
-Once your territory is secured, you will need to prepare for the Plague of Undeath and the invasion of the Burning Legion. Lordaeron will surely need your help.
-
-Your mages are the finest in Azeroth, be sure to utilize them alongside your heroes to turn the tide of battle.";
       GoldMines = new List<unit>
       {
         preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(9204, 2471))

--- a/src/WarcraftLegacies.Source/Factions/Draenei.cs
+++ b/src/WarcraftLegacies.Source/Factions/Draenei.cs
@@ -20,7 +20,7 @@ namespace WarcraftLegacies.Source.Factions
 
     /// <inheritdoc />
     public Draenei(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("The Exodar",
-      PLAYER_COLOR_NAVY, "|cff000080", @"ReplaceableTextures\CommandButtons\BTNBOSSVelen.blp")
+      new[] {PLAYER_COLOR_NAVY, PLAYER_COLOR_BLUE, PLAYER_COLOR_CYAN}, @"ReplaceableTextures\CommandButtons\BTNBOSSVelen.blp")
     {
       TraditionalTeam = TeamSetup.NightElves;
       _preplacedUnitSystem = preplacedUnitSystem;

--- a/src/WarcraftLegacies.Source/Factions/Draenei.cs
+++ b/src/WarcraftLegacies.Source/Factions/Draenei.cs
@@ -28,13 +28,11 @@ namespace WarcraftLegacies.Source.Factions
       _artifactSetup = artifactSetup;
       StartingGold = 200;
       ControlPointDefenderUnitTypeId = UNIT_U008_CONTROL_POINT_DEFENDER_DRAENEI;
-      IntroText = @"You are playing as the exiled |cff000080Draenei|r.
+      IntroText = $"You are playing as the exiled {PrefixCol}Draenei|r.\n\n" +
+                  "You begin on Azuremyst Island, amid the wreckage of your flight from the Burning Legion.\n\n" +
+                  "Further inland your Night-elf allies will need your help against the Old Gods. Quickly build your base and gain entry to the Exodar.\n\n" +
+                  "Power up your buildings with your Arcane Wells to unlock powerful global abilities.";
 
-You begin on Azuremyst Island, amid the wreckage of your flight from the Burning Legion.
-
-Further inland your Night-elf allies will need your help against the Old Gods, quickly build your base and gain entry to the Exodar.
-
-Power up your buildings with your Arcane Wells to unlock powerful global abilities.";
       GoldMines = new List<unit>
       {
         preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(-21000, 8600))

--- a/src/WarcraftLegacies.Source/Factions/Druids.cs
+++ b/src/WarcraftLegacies.Source/Factions/Druids.cs
@@ -25,7 +25,7 @@ namespace WarcraftLegacies.Source.Factions
     /// <inheritdoc />
     
     public Druids(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) :
-      base("Druids", PLAYER_COLOR_BROWN, "|c004e2a04", @"ReplaceableTextures\CommandButtons\BTNFurion.blp")
+      base("Druids", new[] {PLAYER_COLOR_BROWN, PLAYER_COLOR_WHEAT, PLAYER_COLOR_LAVENDER}, @"ReplaceableTextures\CommandButtons\BTNFurion.blp")
     {
       TraditionalTeam = TeamSetup.Kalimdor;
       _preplacedUnitSystem = preplacedUnitSystem;

--- a/src/WarcraftLegacies.Source/Factions/Druids.cs
+++ b/src/WarcraftLegacies.Source/Factions/Druids.cs
@@ -35,14 +35,12 @@ namespace WarcraftLegacies.Source.Factions
       StartingGold = 200;
       CinematicMusic = "DarkAgents";
       ControlPointDefenderUnitTypeId = UNIT_E01Y_CONTROL_POINT_DEFENDER_DRUIDS;
-      IntroText = @"You are playing as the ancient Druids of the Cenarion Circle.
+      IntroText = $"You are playing as the ancient {PrefixCol}Druids of the Cenarion Circle|r.\n\n" +
+                  "You begin isolated in the deepest parts of Mount Hyjal near the World Tree.\n\n" +
+                  "The Old Gods are gathering to burn Ashenvale forest and the World Tree. Cenarius has emerged from his seclusion to stop them. " +
+                  "Use him to awaken Malfurion from his slumber as soon as possible.\n\n" +
+                  "Gather your forces and strike before the Old Gods can organize their efforts.";
 
-You begin isolated in the deepest parts of Mount Hyjal near the World Tree.
-
-The Old Gods are  gathering to burn Ashenvale forest and the World Tree. Cenarius has emerged from his seclusion to stop them. 
-Use him to awaken Malfurion from his slumber as soon as possible.
-
-Gather your forces and strike before the Old Gods can organize their efforts.";
       GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(-9200, 10742))

--- a/src/WarcraftLegacies.Source/Factions/FelHorde.cs
+++ b/src/WarcraftLegacies.Source/Factions/FelHorde.cs
@@ -29,13 +29,11 @@ namespace WarcraftLegacies.Source.Factions
       StartingGold = 200;
       CinematicMusic = "Doom";
       ControlPointDefenderUnitTypeId = UNIT_N0AA_CONTROL_POINT_DEFENDER_FEL_HORDE;
-      IntroText = @"You are playing as the bloodthirsty Fel Horde.
+      IntroText = IntroText = $"You are playing as the bloodthirsty {PrefixCol}Fel Horde|r.\n\n" +
+                              "You begin in Nagrand, cut off from your forces in Hellfire Citadel. You must raise an army and quickly conquer Outland.\n\n" +
+                              "Once Outland is under your control, gather your hordes and prepare to invade Azeroth through the Dark Portal.\n\n" +
+                              "The Alliance is gathering outside the Dark Portal to stop you, so prepare for a very hard breakout.";
 
-You begin in Nagrand, cut off from your forces in Hellfire Citadel. You must raise an army and quickly conquer Outland.
-
-Once Outland is under your control, gather your hordes and prepare to invade Azeroth through the Dark Portal.
-
-The Alliance is gathering outside the Dark Portal to stop you, so prepare for a very hard breakout.";
       FoodMaximum = 250;
       GoldMines = new List<unit>
       {

--- a/src/WarcraftLegacies.Source/Factions/FelHorde.cs
+++ b/src/WarcraftLegacies.Source/Factions/FelHorde.cs
@@ -19,7 +19,7 @@ namespace WarcraftLegacies.Source.Factions
     /// <inheritdoc />
     
     public FelHorde(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Fel Horde",
-      PLAYER_COLOR_GREEN, "|c0020c000", @"ReplaceableTextures\CommandButtons\BTNPitLord.blp")
+      new[] {PLAYER_COLOR_GREEN, PLAYER_COLOR_EMERALD, PLAYER_COLOR_CYAN}, @"ReplaceableTextures\CommandButtons\BTNPitLord.blp")
     {
       TraditionalTeam = TeamSetup.Outland;
       _preplacedUnitSystem = preplacedUnitSystem;

--- a/src/WarcraftLegacies.Source/Factions/Frostwolf.cs
+++ b/src/WarcraftLegacies.Source/Factions/Frostwolf.cs
@@ -34,11 +34,10 @@ namespace WarcraftLegacies.Source.Factions
       StartingGold = 200;
       CinematicMusic = "SadMystery";
       ControlPointDefenderUnitTypeId = UNIT_N0B6_CONTROL_POINT_DEFENDER_FROSTWOLF;
-      IntroText = @"You are playing as the honorable |cffff0000Frostwolf Clan|r.
+      IntroText = $"You are playing as the honorable {PrefixCol}Frostwolf Clan|r.\n\n" +
+                  "You begin in Ashenvale, make your way south to establish your bases, the Echo Isles and Thunder Bluff.\n\n" +
+                  "Your allies will be coming south to help you defend against the Old Gods, do not engage them alone.";
 
-You begin in Ashenvale, make your way south to establish your bases, the Echo Isles and Thunder Bluff.
-
-Your allies will be coming south to help you defend against the Old Gods, do not engage them alone.";
       GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(-9729, 2426)),

--- a/src/WarcraftLegacies.Source/Factions/Frostwolf.cs
+++ b/src/WarcraftLegacies.Source/Factions/Frostwolf.cs
@@ -23,7 +23,7 @@ namespace WarcraftLegacies.Source.Factions
     /// <inheritdoc />
 
     public Frostwolf(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup,
-      ArtifactSetup artifactSetup) : base("Frostwolf", PLAYER_COLOR_RED, "|c00ff0303",
+      ArtifactSetup artifactSetup) : base("Frostwolf", new[] {PLAYER_COLOR_RED, PLAYER_COLOR_GREEN, PLAYER_COLOR_PINK},
       @"ReplaceableTextures\CommandButtons\BTNThrall.blp")
     {
       TraditionalTeam = TeamSetup.Kalimdor;

--- a/src/WarcraftLegacies.Source/Factions/Gilneas.cs
+++ b/src/WarcraftLegacies.Source/Factions/Gilneas.cs
@@ -19,7 +19,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly unit _gilneasGate;
 
     /// <inheritdoc />
-    public Gilneas(PreplacedUnitSystem preplacedUnitSystem, ArtifactSetup artifactSetup, AllLegendSetup allLegendSetup) : base("Gilneas", PLAYER_COLOR_COAL, "|cff808080",
+    public Gilneas(PreplacedUnitSystem preplacedUnitSystem, ArtifactSetup artifactSetup, AllLegendSetup allLegendSetup) : base("Gilneas", new[] {PLAYER_COLOR_COAL, PLAYER_COLOR_LIGHT_GRAY, PLAYER_COLOR_MINT},
       @"ReplaceableTextures\CommandButtons\BTNGreymane.blp")
     {
       TraditionalTeam = TeamSetup.NorthAlliance;

--- a/src/WarcraftLegacies.Source/Factions/Gilneas.cs
+++ b/src/WarcraftLegacies.Source/Factions/Gilneas.cs
@@ -28,13 +28,11 @@ namespace WarcraftLegacies.Source.Factions
       _gilneasGate = preplacedUnitSystem.GetUnit(UNIT_H02K_GREYMANE_S_GATE_CLOSED);
       StartingGold = 200;
       ControlPointDefenderUnitTypeId = UNIT_H0AF_CONTROL_POINT_DEFENDER_GILNEAS;
-      IntroText = @"You are playing as the accursed |cff646464Kingdom of Gilneas|r|r.
+      IntroText = $"You are playing as the accursed {PrefixCol}Kingdom of Gilneas|r.\n\n" +
+                  "You start isolated behind the Greymane Wall; the only way for an enemy to reach you is through the Greymane Gate or via the coast.\n\n" +
+                  "You must raise an army and fight back against the feral wolves and worgen that have overrun your Kingdom.\n\n" +
+                  "Once you have reclaimed Gilneas, open Greymane's Gate and march North to assist Lordaeron and Dalaran with the plague, if it's not too late.";
 
-You start isolated behind the Greymane Wall, the only way for an enemy to reach you is through the Greymane Gate or via the coast.
-
-You must raise an army and fight back against the feral wolves and worgen that have overrun  your Kingdom.
-
-Once you have reclaimed Gilneas, open Greymane's Gate and march North to assist Lordaeron and Dalaran with the plague, if it's not too late.";
       GoldMines = new List<unit>
       {
         preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(9392, -921)),

--- a/src/WarcraftLegacies.Source/Factions/Illidari.cs
+++ b/src/WarcraftLegacies.Source/Factions/Illidari.cs
@@ -20,8 +20,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly ArtifactSetup _artifactSetup;
 
     /// <inheritdoc />
-    public Illidari(AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Illidan", PLAYER_COLOR_VIOLET,
-      "|cffff00ff", @"ReplaceableTextures\CommandButtons\BTNEvilIllidan.blp")
+    public Illidari(AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Illidan", new[] {PLAYER_COLOR_VIOLET, PLAYER_COLOR_PURPLE, PLAYER_COLOR_PINK}, @"ReplaceableTextures\CommandButtons\BTNEvilIllidan.blp")
     {
       TraditionalTeam = TeamSetup.Outland;
       _allLegendSetup = allLegendSetup;

--- a/src/WarcraftLegacies.Source/Factions/Illidari.cs
+++ b/src/WarcraftLegacies.Source/Factions/Illidari.cs
@@ -29,13 +29,11 @@ namespace WarcraftLegacies.Source.Factions
       StartingGold = 200;
       FoodMaximum = 250;
       ControlPointDefenderUnitTypeId = UNIT_N0BB_CONTROL_POINT_DEFENDER_ILLIDARI_TOWER;
-      IntroText = @"You are playing as the Betrayer, Illidan|r|r.
+      IntroText = $"You are playing as the Betrayer, {PrefixCol}Illidan|r.\n\n" +
+                  "You begin on the Broken Isles, ready to plunder the tombs for artifacts to empower Illidan.\n\n" +
+                  "Unfortunately, you cannot progress further in the Islands. Use Illidan's mastery of portals to travel to Outland and join forces with your ally.\n\n" +
+                  "Support your ally in Outland by unlocking bases and coordinating with his push out of the Dark Portal.";
 
-You begin on the Broken Isles, ready to plunder the tombs for artifacts to empower Illidan.
-
-Unfortunately, you cannot progress further in the Islands. Use Illidan's mastery of portals to travel to Outland and join forces with your ally.
-
-Support your ally in Outland by unlocking bases and coordinating with his push out of the Dark Portal.";
       Nicknames = new List<string>
       {
         "illi",

--- a/src/WarcraftLegacies.Source/Factions/Illidari.cs
+++ b/src/WarcraftLegacies.Source/Factions/Illidari.cs
@@ -20,7 +20,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly ArtifactSetup _artifactSetup;
 
     /// <inheritdoc />
-    public Illidari(AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Illidan", new[] {PLAYER_COLOR_LIGHT_BLUE, PLAYER_COLOR_COAL, PLAYER_COLOR_PINK}, @"ReplaceableTextures\CommandButtons\BTNEvilIllidan.blp")
+    public Illidari(AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Illidan", new[] {PLAYER_COLOR_VIOLET, PLAYER_COLOR_PURPLE, PLAYER_COLOR_PINK}, @"ReplaceableTextures\CommandButtons\BTNEvilIllidan.blp")
     {
       TraditionalTeam = TeamSetup.Outland;
       _allLegendSetup = allLegendSetup;

--- a/src/WarcraftLegacies.Source/Factions/Illidari.cs
+++ b/src/WarcraftLegacies.Source/Factions/Illidari.cs
@@ -20,7 +20,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly ArtifactSetup _artifactSetup;
 
     /// <inheritdoc />
-    public Illidari(AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Illidan", new[] {PLAYER_COLOR_VIOLET, PLAYER_COLOR_PURPLE, PLAYER_COLOR_PINK}, @"ReplaceableTextures\CommandButtons\BTNEvilIllidan.blp")
+    public Illidari(AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Illidan", new[] {PLAYER_COLOR_LIGHT_BLUE, PLAYER_COLOR_COAL, PLAYER_COLOR_PINK}, @"ReplaceableTextures\CommandButtons\BTNEvilIllidan.blp")
     {
       TraditionalTeam = TeamSetup.Outland;
       _allLegendSetup = allLegendSetup;

--- a/src/WarcraftLegacies.Source/Factions/Ironforge.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge.cs
@@ -30,11 +30,10 @@ namespace WarcraftLegacies.Source.Factions
       StartingGold = 200;
       CinematicMusic = "PursuitTheme";
       ControlPointDefenderUnitTypeId = UNIT_H0AL_CONTROL_POINT_DEFENDER_IRONFORGE;
-      IntroText = @"You are playing as the long-enduring |cffe4bc00Kingdom of 
-                    |r
-You begin in the Wetlands, separated from the rest of your forces. Conquer Loch Modan and Dun Morough to gain access to 
- 
-Stormwind is preparing for an invasion through the Dark Portal in the South. Muster the throng and help them, or you may lose your strongest ally.";
+      IntroText = $"You are playing as the long-enduring {PrefixCol}Kingdom of |r.\n\n" +
+                  "You begin in the Wetlands, separated from the rest of your forces. Conquer Loch Modan and Dun Morogh to regain access to your territories.\n\n" +
+                  "Stormwind is preparing for an invasion through the Dark Portal in the South. Muster your forces and aid them, or risk losing your strongest ally.";
+
       GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(12079, -2768))

--- a/src/WarcraftLegacies.Source/Factions/Ironforge.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge.cs
@@ -20,7 +20,7 @@ namespace WarcraftLegacies.Source.Factions
     /// <inheritdoc />
     
     public Ironforge(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Ironforge",
-      PLAYER_COLOR_YELLOW, "|C00FFFC01", @"ReplaceableTextures\CommandButtons\BTNHeroMountainKing.blp")
+      new[] {PLAYER_COLOR_YELLOW, PLAYER_COLOR_ORANGE, PLAYER_COLOR_LIGHT_BLUE}, @"ReplaceableTextures\CommandButtons\BTNHeroMountainKing.blp")
     {
       TraditionalTeam = TeamSetup.SouthAlliance;
       _preplacedUnitSystem = preplacedUnitSystem;

--- a/src/WarcraftLegacies.Source/Factions/Kultiras.cs
+++ b/src/WarcraftLegacies.Source/Factions/Kultiras.cs
@@ -20,7 +20,7 @@ namespace WarcraftLegacies.Source.Factions
     /// <inheritdoc />
     
     public Kultiras(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Kul'tiras",
-      PLAYER_COLOR_EMERALD, "|cff00781e", @"ReplaceableTextures\CommandButtons\BTNProudmoore.blp")
+      new[] {PLAYER_COLOR_EMERALD, PLAYER_COLOR_TURQUOISE, PLAYER_COLOR_CYAN}, @"ReplaceableTextures\CommandButtons\BTNProudmoore.blp")
     {
       TraditionalTeam = TeamSetup.SouthAlliance;
       _allLegendSetup = allLegendSetup;

--- a/src/WarcraftLegacies.Source/Factions/Kultiras.cs
+++ b/src/WarcraftLegacies.Source/Factions/Kultiras.cs
@@ -28,11 +28,10 @@ namespace WarcraftLegacies.Source.Factions
       _proudmooreCapitalShip = preplacedUnitSystem.GetUnit(UNIT_H05V_PROUDMOORE_FLAGSHIP_KUL_TIRAS);
       StartingGold = 200;
       ControlPointDefenderUnitTypeId = UNIT_H09W_CONTROL_POINT_DEFENDER_KUL_TIRAS;
-      IntroText = @"You are playing as the maritime |cff008000Kingdom of Kul'tiras|r.
+      IntroText = $"You are playing as the maritime {PrefixCol}Kingdom of Kul Tiras|r.\n\n" +
+                  "You begin on Balor Island, separated from your main forces in Kul Tiras. Unite your forces by eliminating your enemies in Tiragarde, Drustvar, and Stormsong Valley.\n\n" +
+                  "Stormwind is preparing for an invasion through the Dark Portal in the South. Muster the Admiralty and assist them, or risk losing your strongest ally.";
 
-You begin on Balor island, separated from your main forces in Kul Tiras. Unite your forces by eliminating your enemies in Tiragarde, Drustvar and Stormsong Valley.
-
-Stormwind is preparing for an invasion through the Dark Portal in the South. Muster the Admiralty and help them, or you may lose your strongest ally.";
       GoldMines = new List<unit>
       {
         preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(4585, -13038))

--- a/src/WarcraftLegacies.Source/Factions/Legion.cs
+++ b/src/WarcraftLegacies.Source/Factions/Legion.cs
@@ -34,13 +34,11 @@ namespace WarcraftLegacies.Source.Factions
       FoodMaximum = 250;
       CinematicMusic = "DarkAgents";
       ControlPointDefenderUnitTypeId = UNIT_U01U_CONTROL_POINT_DEFENDER_LEGION;
-      IntroText = @"You are playing as the mighty |cffa2722dBurning Legion|r.
+      IntroText = $"You are playing as the mighty {PrefixCol}Burning Legion|r.\n\n" +
+                  "You begin isolated on Argus. Once the planet is under your control, you will unlock two teleporters to Northrend and Alterac.\n\n" +
+                  "On Azeroth, the Scourge will need your assistance to destroy the Kingdoms of Lordaeron, Dalaran, and Quel'Thalas.\n\n" +
+                  "Your primary objective is to summon the great host of the Burning Legion. Invade the city of Dalaran, where the Book of Medivh is kept, and use it to open the Demon-gate to Argus.";
 
-You begin isolated on Argus. Once the Planet is under control, you will unlock 2 teleporters to Northrend and Alterac.
-
-On Azeroth, the Scourge will need your assistance to destroy the Kingdoms of Lordaeron, Dalaran and Quel'thalas.
-
-Your primary objective is to summon the great host of the Burning Legion. Invade the city of Dalaran, where the book of Medivh is kept, and use it to open the Demon-gate to Argus.";
       GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(19331f, -30663))

--- a/src/WarcraftLegacies.Source/Factions/Legion.cs
+++ b/src/WarcraftLegacies.Source/Factions/Legion.cs
@@ -24,7 +24,7 @@ namespace WarcraftLegacies.Source.Factions
     /// <inheritdoc />
     
     public Legion(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup) : base("Legion",
-      PLAYER_COLOR_PEANUT, "|CFFBF8F4F", @"ReplaceableTextures\CommandButtons\BTNKiljaedin.blp")
+      new[] {PLAYER_COLOR_PEANUT, PLAYER_COLOR_WHEAT, PLAYER_COLOR_VIOLET}, @"ReplaceableTextures\CommandButtons\BTNKiljaedin.blp")
     {
       TraditionalTeam = TeamSetup.Legion;
       _preplacedUnitSystem = preplacedUnitSystem;

--- a/src/WarcraftLegacies.Source/Factions/Lordaeron.cs
+++ b/src/WarcraftLegacies.Source/Factions/Lordaeron.cs
@@ -37,13 +37,11 @@ namespace WarcraftLegacies.Source.Factions
       UndefeatedResearch = UPGRADE_R05M_LORDAERON_EXISTS;
       CinematicMusic = "Comradeship";
       ControlPointDefenderUnitTypeId = UNIT_H03W_CONTROL_POINT_DEFENDER_LORDAERON;
-      IntroText = @"You are playing as the great |cff4242ebKingdom of Lordaeron|r.
+      IntroText = $"You are playing as the great {PrefixCol}Kingdom of Lordaeron|r.\n\n" +
+                  "You begin in Andorhal, isolated from your forces in the rest of the Kingdom, and the Plague of Undeath is imminent.\n\n" +
+                  "Secure your major settlements by clearing out clusters of enemies and fortify your Kingdom as much as possible.\n\n" +
+                  "If you survive the Plague, sail to the frozen wasteland of Northrend and take the fight to the Lich King.";
 
-You begin in Andorhal, isolated from your forces in the rest of the Kingdom, and the Plague of Undeath is coming.
-
-Secure your major settlements by clearing out clusters of enemies and fortify your Kingdom as much as possible.
-
-If you survive the Plague, sail to the frozen wasteland of Northrend and take the fight to the Lich King.";
       GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(13617, 8741)),

--- a/src/WarcraftLegacies.Source/Factions/Lordaeron.cs
+++ b/src/WarcraftLegacies.Source/Factions/Lordaeron.cs
@@ -27,7 +27,7 @@ namespace WarcraftLegacies.Source.Factions
     /// <inheritdoc />
     
     public Lordaeron(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Lordaeron",
-      PLAYER_COLOR_LIGHT_BLUE, "|cff8080ff", @"ReplaceableTextures\CommandButtons\BTNArthas.blp")
+      new[] {PLAYER_COLOR_LIGHT_BLUE, PLAYER_COLOR_AQUA, PLAYER_COLOR_PEACH}, @"ReplaceableTextures\CommandButtons\BTNArthas.blp")
     {
       TraditionalTeam = TeamSetup.NorthAlliance;
       _preplacedUnitSystem = preplacedUnitSystem;

--- a/src/WarcraftLegacies.Source/Factions/Nazjatar.cs
+++ b/src/WarcraftLegacies.Source/Factions/Nazjatar.cs
@@ -7,7 +7,7 @@ namespace WarcraftLegacies.Source.Factions
   public sealed class Nazjatar : Faction
   {
     /// <inheritdoc />
-    public Nazjatar() : base("Nazjatar", PLAYER_COLOR_PURPLE, "|c00540081",
+    public Nazjatar() : base("Nazjatar", new[] {PLAYER_COLOR_PURPLE, PLAYER_COLOR_VIOLET, PLAYER_COLOR_LIGHT_GRAY},
       @"ReplaceableTextures\CommandButtons\BTNNagaSummoner.blp")
     {
       ControlPointDefenderUnitTypeId = UNIT_U02T_CONTROL_POINT_DEFENDER_NAZJATAR;

--- a/src/WarcraftLegacies.Source/Factions/Quelthalas.cs
+++ b/src/WarcraftLegacies.Source/Factions/Quelthalas.cs
@@ -30,14 +30,11 @@ namespace WarcraftLegacies.Source.Factions
       StartingGold = 200;
       CinematicMusic = "BloodElfTheme";
       ControlPointDefenderUnitTypeId = UNIT_N0BC_CONTROL_POINT_DEFENDER_QUELTHALAS;
-      IntroText = @"You are playing as the proud |cff32e1e1Kingdom of Quel'thalas|r.
+      IntroText = $"You are playing as the proud {PrefixCol}Kingdom of Quel'Thalas|r.\n\n" +
+                  "You begin in Tranquillien, separated from Silvermoon. The Trolls of Zul'Aman have laid siege to the city and are preparing attacks on your base.\n\n" +
+                  "Train soldiers to repel the attacks, then gather enough strength to besiege Zul'Aman and take the head of Zul'jin.\n\n" +
+                  "The Plague of Undeath is imminent, and Lordaeron will soon need your help against the Scourge. Be ready to join them once you have secured Silvermoon and dealt with the Amani invasion.";
 
-You begin in Tranquilien, separated from Silvermoon.
-The Trolls of Zul'Aman have laid siege to the city, and are preparing attacks on your base.
-
-Train soldiers to repel the attacks, then gather enough strength to besiege Zul'Aman and take the head of Zul'jin.
-
-The Plague of Undeath is coming and Lordaeron will need your help with the Scourge soon. Be ready to join them as once you have secured Silvermoon and dealt with the Amani invasion.";
       GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(17716, 13000))

--- a/src/WarcraftLegacies.Source/Factions/Quelthalas.cs
+++ b/src/WarcraftLegacies.Source/Factions/Quelthalas.cs
@@ -20,7 +20,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly AllLegendSetup _allLegendSetup;
 
     /// <inheritdoc />
-    public Quelthalas(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup) : base("Quel'thalas", PLAYER_COLOR_CYAN, "|C0000FFFF",
+    public Quelthalas(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup) : base("Quel'thalas", new[] {PLAYER_COLOR_CYAN, PLAYER_COLOR_MINT, PLAYER_COLOR_GREEN},
       @"ReplaceableTextures\CommandButtons\BTNSylvanusWindrunner.blp")
     {
       TraditionalTeam = TeamSetup.NorthAlliance;

--- a/src/WarcraftLegacies.Source/Factions/ScarletCrusade.cs
+++ b/src/WarcraftLegacies.Source/Factions/ScarletCrusade.cs
@@ -17,15 +17,12 @@ namespace WarcraftLegacies.Source.Factions
       _allLegendSetup = allLegendSetup;
       StartingGold = 200;
       ControlPointDefenderUnitTypeId = UNIT_H09O_CONTROL_POINT_DEFENDER_CRUSADE;
-      IntroText = @"You are playing as the zealous |cff940000Scarlet Crusade|r.
+      IntroText = $"You are playing as the zealous {PrefixCol}Scarlet Crusade|r.\n\n" +
+                  "The Cult of the Damned has mobilized and is quietly spreading corruption throughout Lordaeron.\n\n" +
+                  "Construct towers to detect hidden cultists moving through the Kingdom, and burn any buildings they have corrupted.\n\n" +
+                  "Your soldiers are weaker when alone but gain substantial bonuses when paired with a variety of unit types.\n\n" +
+                  "Fortify your strongholds against the storm to come, and prepare to unleash the Crusade on those who defile your lands.";
 
-The Cult of the Damned has mobilized and is quietly spreading corruption throughout Lordaeron.
-
-Build towers to detect the hidden cultists moving through the Kingdom and burn any buildings they have corrupted.
-
-Your soldiers are weaker when alone, but gain substantial bonuses when paired with a variety of unit-types. 
-
-Fortify your strongholds against the storm to come and make ready to unleash the Crusade on those who would defile your lands.";
       Nicknames = new List<string>
       {
         "sc",

--- a/src/WarcraftLegacies.Source/Factions/ScarletCrusade.cs
+++ b/src/WarcraftLegacies.Source/Factions/ScarletCrusade.cs
@@ -11,7 +11,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly AllLegendSetup _allLegendSetup;
 
     /// <inheritdoc />
-    public ScarletCrusade(AllLegendSetup allLegendSetup) : base("Scarlet Crusade", PLAYER_COLOR_MAROON, "|cff800000",
+    public ScarletCrusade(AllLegendSetup allLegendSetup) : base("Scarlet Crusade", new[] {PLAYER_COLOR_MAROON, PLAYER_COLOR_RED, PLAYER_COLOR_PEACH},
       "ReplaceableTextures/CommandButtons/BTNScarletKnight.blp")
     {
       _allLegendSetup = allLegendSetup;

--- a/src/WarcraftLegacies.Source/Factions/Scourge.cs
+++ b/src/WarcraftLegacies.Source/Factions/Scourge.cs
@@ -26,7 +26,7 @@ namespace WarcraftLegacies.Source.Factions
     /// <inheritdoc />
     
     public Scourge(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup)
-      : base("Scourge", PLAYER_COLOR_PURPLE, "|c00540081",
+      : base("Scourge", new[] {PLAYER_COLOR_PURPLE, PLAYER_COLOR_VIOLET, PLAYER_COLOR_EMERALD, PLAYER_COLOR_RED},
         @"ReplaceableTextures\CommandButtons\BTNRevenant.blp")
     {
       TraditionalTeam = TeamSetup.Legion;

--- a/src/WarcraftLegacies.Source/Factions/Scourge.cs
+++ b/src/WarcraftLegacies.Source/Factions/Scourge.cs
@@ -38,15 +38,12 @@ namespace WarcraftLegacies.Source.Factions
       FoodMaximum = 250;
       CinematicMusic = "ArthasTheme";
       ControlPointDefenderUnitTypeId = UNIT_U028_CONTROL_POINT_DEFENDER_SCOURGE;
-      IntroText = @"You are playing as the the horrific Undead Scourge.
+      IntroText = $"You are playing as the horrific {PrefixCol}Undead Scourge|r.\n\n" +
+                  "You begin in Northrend, a vast and isolated land—perfect for raising an army of undying warriors to annihilate the living.\n\n" +
+                  "The local Nerubians have declared war on you. Destroy their decrepit holdings and slay their Queen to secure the continent.\n\n" +
+                  "Coordinate with the Burning Legion and unleash the Plague of Undeath to sweep Lordaeron away.\n\n" +
+                  "When the Plague strikes Lordaeron, you will have a choice of where to instantly transport all your military units.";
 
-You begin in Northrend, a vast and isolated land; perfect to raise an army of undying warriors to destroy the living.
-
-The local Nerubians have declared war on you. Destroy their decrepit holdings and kill their Queen to secure the continent.
-
-Coordinate with the Burning Legion and use the Plague of Undeath to sweep Lordaeron away.
-
-When the Plague hits Lordaeron, you will have a choice to where you want all your military units to be instantly transported.";
       GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(-4939, 18803))

--- a/src/WarcraftLegacies.Source/Factions/Sentinels.cs
+++ b/src/WarcraftLegacies.Source/Factions/Sentinels.cs
@@ -22,7 +22,7 @@ namespace WarcraftLegacies.Source.Factions
     private readonly ArtifactSetup _artifactSetup;
 
     /// <inheritdoc />
-    public Sentinels(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Sentinels", PLAYER_COLOR_MINT, "|CFFBFFF80",
+    public Sentinels(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Sentinels", new[] {PLAYER_COLOR_MINT, PLAYER_COLOR_CYAN, PLAYER_COLOR_AQUA},
       @"ReplaceableTextures\CommandButtons\BTNPriestessOfTheMoon.blp")
     {
       TraditionalTeam = TeamSetup.Kalimdor;

--- a/src/WarcraftLegacies.Source/Factions/Sentinels.cs
+++ b/src/WarcraftLegacies.Source/Factions/Sentinels.cs
@@ -32,14 +32,11 @@ namespace WarcraftLegacies.Source.Factions
       StartingGold = 200;
       CinematicMusic = "Comradeship";
       ControlPointDefenderUnitTypeId = UNIT_H03F_CONTROL_POINT_DEFENDER_SENTINELS;
-      IntroText = @"You are playing as the ever-watchful |CFFBFFF80Sentinels|r.
+      IntroText =$"You are playing as the ever-watchful {PrefixCol}Sentinels|r.\n\n" +
+                 "The Druids are slowly waking from their slumber, and it falls to you to drive back the Old Gods' invaders from Kalimdor until then.\n\n" +
+                 "Your first mission is to race down the coast to Feathermoon Stronghold, a powerful Sentinel bastion on the southern half of the continent.\n\n" +
+                 "Once you have secured your holdings, gather your army and destroy the Old Gods. Be cautious—they will outnumber you if given time to establish a foothold in Azeroth.";
 
-
-The Druids are slowly waking from their slumber, and it falls to you to drive back the Old Gods invaders from Kalimdor until then.
-
-Your first mission is to race down the coast to Feathermoon Stronghold, a powerful Sentinel stronghold on the southern half of the continent. 
-
-Once you have secured your holdings, gather your army and destroy the Old Gods. Be careful, they will outnumber you if given time to establish a foothold in Azeroth.";
       GoldMines = new List<unit>
       {
         preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(-20780, 7860))

--- a/src/WarcraftLegacies.Source/Factions/Skywall.cs
+++ b/src/WarcraftLegacies.Source/Factions/Skywall.cs
@@ -19,7 +19,7 @@ namespace WarcraftLegacies.Source.Factions
   {
     private readonly AllLegendSetup _allLegendSetup;
     /// <inheritdoc />
-    public Skywall(AllLegendSetup allLegendSetup) : base("Skywall", PLAYER_COLOR_LIGHT_GRAY, "|cffffffff",
+    public Skywall(AllLegendSetup allLegendSetup) : base("Skywall", new[] {PLAYER_COLOR_LIGHT_GRAY, PLAYER_COLOR_COAL, PLAYER_COLOR_RED},
       @"ReplaceableTextures\CommandButtons\BTNFrostRevenant2.blp")
     {
       ControlPointDefenderUnitTypeId = UNIT_NECP_CONTROL_POINT_DEFENDER_SKYWALL_TOWER;

--- a/src/WarcraftLegacies.Source/Factions/Skywall.cs
+++ b/src/WarcraftLegacies.Source/Factions/Skywall.cs
@@ -26,13 +26,11 @@ namespace WarcraftLegacies.Source.Factions
       TraditionalTeam = TeamSetup.OldGods;
       _allLegendSetup = allLegendSetup;
       StartingGold = 200;
-      IntroText = @"You are playing as the Elementals of Skywall|r|r.
+      IntroText = $"You are playing as the {PrefixCol}Elementals of Skywall|r.\n\n" +
+                  "At the start, clear Uldum and take control of Tanaris.\n\n" +
+                  "Coordinate with your Qiraji ally to push back the Horde before the Druids can intervene.\n\n" +
+                  "You have a powerful event in the Burning of the World Tree. Use it at the right time to surprise the Druids and possibly attack them from behind.";
 
-At the start, clear Uldum and take control of Tanaris. 
-
-Coordinate with your Qiraji ally to push the Horde before the Druids can get there.
-
-You have a very powerful event in the Burning of the World Tree. Use it at the right time to surprise the Druids and maybe attack them from behind.";
       Nicknames = new List<string>
       {
         "sky",

--- a/src/WarcraftLegacies.Source/Factions/Stormwind.cs
+++ b/src/WarcraftLegacies.Source/Factions/Stormwind.cs
@@ -17,7 +17,7 @@ namespace WarcraftLegacies.Source.Factions
 
     /// <inheritdoc />
     
-    public Stormwind(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Stormwind", PLAYER_COLOR_BLUE, "|c000042ff",
+    public Stormwind(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup) : base("Stormwind", new[] {PLAYER_COLOR_BLUE, PLAYER_COLOR_NAVY, PLAYER_COLOR_CYAN},
       @"ReplaceableTextures\CommandButtons\BTNKnight.blp")
     {
       TraditionalTeam = TeamSetup.SouthAlliance;

--- a/src/WarcraftLegacies.Source/Factions/Stormwind.cs
+++ b/src/WarcraftLegacies.Source/Factions/Stormwind.cs
@@ -27,13 +27,11 @@ namespace WarcraftLegacies.Source.Factions
       UndefeatedResearch = UPGRADE_R060_STORMWIND_EXISTS;
       StartingGold = 200;
       ControlPointDefenderUnitTypeId = UNIT_H05X_CONTROL_POINT_DEFENDER_STORMWIND;
-      IntroText = @"You are playing as the steadfast |c000042FFKingdom of Stormwind|r.
+      IntroText = $"You are playing as the steadfast {PrefixCol}Kingdom of Stormwind|r.\n\n" +
+                  "You begin in Westfall, separated from the rest of the kingdom. Reunite your lands by liberating Darkshire, Lakeshire, and finally Stormwind City.\n\n" +
+                  "Once you have unified Stormwind's forces, race east to the Nethergarde Stronghold and prepare for the invasion of the Fel Horde.\n\n" +
+                  "Make sure to communicate with your Dwarven and Kul Tiran allies, as they will be key to defeating the evil that lurks beyond the Dark Portal.";
 
-You begin in Westfall, separated from the rest of the kingdom. Reunite your lands by liberating Darkshire, Lakeshire and finally Stormwind City. 
-
-Once you have unified Stormwind's forces, race East to the Nethergarde Stronghold and prepare for the invasion of the Fel Horde.
-
-Make sure to communicate with your Dwarven and Kul'tiran allies, as they will be key in helping you defeat the evil from beyond the Dark Portal.";
       Nicknames = new List<string>
       {
         "sw",

--- a/src/WarcraftLegacies.Source/Factions/Sunfury.cs
+++ b/src/WarcraftLegacies.Source/Factions/Sunfury.cs
@@ -29,12 +29,11 @@ namespace WarcraftLegacies.Source.Factions
       CinematicMusic = "BloodElfTheme";
       FoodMaximum = 250;
       ControlPointDefenderUnitTypeId = UNIT_N0BC_CONTROL_POINT_DEFENDER_QUELTHALAS;
-      IntroText = @"You are playing as the power-hungry |cffff0000Sunfury|r.
+      IntroText = $"You are playing as the power-hungry {PrefixCol}Sunfury|r.\n\n" +
+                  "You begin in Netherstorm. Your first mission is to build three biodomes in the green areas protected by a bubble.\n\n" +
+                  "Unite with your fel ally to push through the Dark Portal and destroy Stormwind.\n\n" +
+                  "Your ultimate goal is to summon Kil'jaeden and annihilate your enemies.";
 
-You begin in Netherstorm, your first mission is to build three biodomes in the green areas protected by a bubble.
-Unite with your fel ally to push through the Dark Portal and destroy Stormwind. 
-
-Your main goal is to summon Kil'jaeden and destroy your enemies.";
       GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(3295, -22670)),

--- a/src/WarcraftLegacies.Source/Factions/Sunfury.cs
+++ b/src/WarcraftLegacies.Source/Factions/Sunfury.cs
@@ -19,7 +19,7 @@ namespace WarcraftLegacies.Source.Factions
 
     /// <inheritdoc />
     public Sunfury(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup)
-      : base("Sunfury", PLAYER_COLOR_MAROON, "|cffff0000", @"ReplaceableTextures\CommandButtons\BTNBloodMage2.blp")
+      : base("Sunfury", new[] {PLAYER_COLOR_MAROON, PLAYER_COLOR_TURQUOISE, PLAYER_COLOR_PINK}, @"ReplaceableTextures\CommandButtons\BTNBloodMage2.blp")
     {
       TraditionalTeam = TeamSetup.Outland;
       _preplacedUnitSystem = preplacedUnitSystem;

--- a/src/WarcraftLegacies.Source/Factions/Warsong.cs
+++ b/src/WarcraftLegacies.Source/Factions/Warsong.cs
@@ -39,13 +39,11 @@ namespace WarcraftLegacies.Source.Factions
             StartingGold = 200;
             CinematicMusic = "DarkAgents";
             ControlPointDefenderUnitTypeId = UNIT_N0D6_CONTROL_POINT_DEFENDER_WARSONG;
-            IntroText = @"You are playing as the fierce and relentless |cffff7f00Warsong Clan|r.
+            IntroText = $"You are playing as the fierce and relentless {PrefixCol}Warsong Clan|r.\n\n" +
+                        "Begin swiftly by rescuing your Chieftain, Grom Hellscream, who is trapped in battle and consumed by demonic fury. His survival is paramount.\n\n" +
+                        "With Grom secured, expand your dominance by subduing or pillaging nearby races to bolster your clan's strength.\n\n" +
+                        "Work closely with your new elven allies—only together can you overcome the looming threat of the Old Gods.";
 
-Begin swiftly by rescuing your Chieftain, Grom Hellscream, who is trapped in battle, consumed by demonic fury. His survival is paramount.
-
-With Grom secured, you can expand your dominance by subduing or pillaging nearby races to bolster your clan's strength.
-
-Work closely with your new elven allies—only together will you overcome the looming threat of the Old Gods.";
             GoldMines = new List<unit>
       {
         _preplacedUnitSystem.GetUnit(FourCC("ngol"), new Point(-9729, 2426)),

--- a/src/WarcraftLegacies.Source/Factions/Warsong.cs
+++ b/src/WarcraftLegacies.Source/Factions/Warsong.cs
@@ -28,7 +28,7 @@ namespace WarcraftLegacies.Source.Factions
         /// <inheritdoc />
 
         public Warsong(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup)
-          : base("Warsong", PLAYER_COLOR_ORANGE, "|c00ff8000",
+          : base("Warsong", new[] {PLAYER_COLOR_ORANGE, PLAYER_COLOR_YELLOW, PLAYER_COLOR_COAL},
           @"ReplaceableTextures\CommandButtons\BTNHellScream.blp")
         {
             TraditionalTeam = TeamSetup.Horde;

--- a/src/WarcraftLegacies.Source/Factions/Zandalar.cs
+++ b/src/WarcraftLegacies.Source/Factions/Zandalar.cs
@@ -18,7 +18,7 @@ namespace WarcraftLegacies.Source.Factions
 
     /// <inheritdoc />
     public Zandalar(PreplacedUnitSystem preplacedUnitSystem, AllLegendSetup allLegendSetup, ArtifactSetup artifactSetup)
-      : base("Zandalar", PLAYER_COLOR_PEACH, "|cffff8c6c",
+      : base("Zandalar", new[] {PLAYER_COLOR_PEACH, PLAYER_COLOR_PINK, PLAYER_COLOR_LIGHT_GRAY},
         @"ReplaceableTextures\CommandButtons\BTNHeadHunterBerserker.blp")
     {
       TraditionalTeam = TeamSetup.Horde;

--- a/src/WarcraftLegacies.Source/Factions/Zandalar.cs
+++ b/src/WarcraftLegacies.Source/Factions/Zandalar.cs
@@ -27,13 +27,11 @@ namespace WarcraftLegacies.Source.Factions
       _artifactSetup = artifactSetup;
       StartingGold = 200;
       ControlPointDefenderUnitTypeId = UNIT_H0C1_CONTROL_POINT_DEFENDER_ZANDALAR;
-      IntroText = @"You are playing as the mighty |cffe1946cZandalari Empire|r.
+      IntroText = $"You are playing as the mighty {PrefixCol}Zandalari Empire|r.\n\n" +
+                  "You start off on the southern coast of Tanaris, separated from your allies. Raise an army and deal with the rogue trolls in Zul'Farrak.\n\n" +
+                  "The Night Elves are mounting an assault on you and your allies from the north.\n\n" +
+                  "Join forces with your allies and brace yourself for a tough fight and counterattack.";
 
-You start off at the southern coast of Tanaris, seperated from your allies. Raise an army and deal with the rogue Trolls in Zul'Farrak.
-
-The Night Elves are mounting an assault on you and your allies from the North.
-
-Join up with your allies and brace for a tough fight and counter-attack. ";
 
       GoldMines = new List<unit>
       {


### PR DESCRIPTION
## Dynamic Faction Colours 

### Changes 

Each faction is given three prioritised colours. If a colour is already in use, the next available one is selected. If all three are taken, a different unclaimed colour is assigned. When a faction is defeated or leaves, its colour is released and made available for reassignment.


- FactionColourManager class created.
- UI Hex Colours are now linked with player colours. 
- Each faction class updated and have three colours assigned.
- Updated logic in Faction class for Player Colour assignment and Defeat logic. 