### PR TITLE
Technopig/Death Pact/Dark Ritual Fix

### DIFF
--- a/mapdata/WarcraftLegacies/AbilityData/Skin/1127231809.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Skin/1127231809.json
@@ -101,7 +101,7 @@
       "Level": 1,
       "Id": 828536161,
       "Type": 3,
-      "Value": "Sacrifices a friendly Undead unit, giving 150% of its hit points to the Death Knight and 20% of it\u0027s hitpoints in mana. Prioritises summoned units."
+      "Value": "Sacrifices a friendly Undead unit, restoring 150% of its hit points to the Hero as health and 20% as mana. Prioritizes summoned units."
     },
     {
       "Level": 2,

--- a/mapdata/WarcraftLegacies/AbilityData/Skin/1127231809.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Skin/1127231809.json
@@ -101,7 +101,7 @@
       "Level": 1,
       "Id": 828536161,
       "Type": 3,
-      "Value": "Sacrifices a friendly Undead unit, restoring 150% of its hit points to the Hero as health and 20% as mana. Prioritizes summoned units."
+      "Value": "Sacrifices a nearby friendly Undead unit, restoring 150% of its hit points to the Hero as health and 20% as mana. Prioritizes summoned units."
     },
     {
       "Level": 2,

--- a/mapdata/WarcraftLegacies/AbilityData/Skin/1347891265.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Skin/1347891265.json
@@ -101,7 +101,7 @@
       "Level": 1,
       "Id": 828536161,
       "Type": 3,
-      "Value": "Sacrifices a friendly Undead unit, restoring 25% of its hit points to the Hero as health and 35% as mana. Prioritizes summoned units."
+      "Value": "Sacrifices a nearby friendly Undead unit, restoring 25% of its hit points to the Hero as health and 35% as mana. Prioritizes summoned units."
     },
     {
       "Level": 2,

--- a/mapdata/WarcraftLegacies/AbilityData/Skin/1347891265.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Skin/1347891265.json
@@ -101,7 +101,7 @@
       "Level": 1,
       "Id": 828536161,
       "Type": 3,
-      "Value": "Sacrifices a friendly Undead unit, giving 35% of its hit points to the Death Knight and 25% of it\u0027s hitpoints in mana. Prioritises summoned units."
+      "Value": "Sacrifices a friendly Undead unit, restoring 25% of its hit points to the Hero as health and 35% as mana. Prioritizes summoned units."
     },
     {
       "Level": 2,

--- a/mapdata/WarcraftLegacies/AbilityData/Skin/962015297.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Skin/962015297.json
@@ -101,7 +101,7 @@
       "Level": 1,
       "Id": 828536161,
       "Type": 3,
-      "Value": "Sacrifices a friendly Undead unit, giving 125% of its hit points to the Death Knight and 10% of it\u0027s hitpoints in mana. Prioritises summoned units."
+      "Value": "Sacrifices a friendly Undead unit, restoring 125% of its hit points to the Death Knight as health and 10% as mana. Prioritizes summoned units."
     },
     {
       "Level": 2,

--- a/mapdata/WarcraftLegacies/AbilityData/Skin/962015297.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Skin/962015297.json
@@ -101,7 +101,7 @@
       "Level": 1,
       "Id": 828536161,
       "Type": 3,
-      "Value": "Sacrifices a friendly Undead unit, restoring 125% of its hit points to the Death Knight as health and 10% as mana. Prioritizes summoned units."
+      "Value": "Sacrifices a nearby friendly Undead unit, restoring 125% of its hit points to the Death Knight as health and 10% as mana. Prioritizes summoned units."
     },
     {
       "Level": 2,

--- a/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
@@ -179,7 +179,7 @@ namespace WarcraftLegacies.Source.Setup.Spells
           KillEffect = @"Abilities\Spells\Undead\DarkRitual\DarkRitualTarget.mdl",
           HealEffect = @"Abilities\Spells\Undead\ReplenishMana\SpiritTouchTarget.mdl",
           HealthRestorePercent = 0.25f,
-          ManaRestorePercent = 0.36f,
+          ManaRestorePercent = 0.3f,
         };
 
         SpellSystem.Register(darkRitual);

--- a/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
@@ -179,7 +179,7 @@ namespace WarcraftLegacies.Source.Setup.Spells
           KillEffect = @"Abilities\Spells\Undead\DarkRitual\DarkRitualTarget.mdl",
           HealEffect = @"Abilities\Spells\Undead\ReplenishMana\SpiritTouchTarget.mdl",
           HealthRestorePercent = 0.25f,
-          ManaRestorePercent = 0.3f,
+          ManaRestorePercent = 0.35f,
         };
 
         SpellSystem.Register(darkRitual);

--- a/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/Spells/ScourgeSpellSetup.cs
@@ -155,7 +155,7 @@ namespace WarcraftLegacies.Source.Setup.Spells
           KillEffect = @"Abilities\Spells\Undead\DeathPact\DeathPactTarget.mdl",
           HealEffect = @"Abilities\Spells\Human\Heal\HealTarget.mdl",
           HealthRestorePercent = 1.25f, 
-          ManaRestorePercent = 0.10f 
+          ManaRestorePercent = 0.10f,
         };
 
         SpellSystem.Register(deathPact);
@@ -166,7 +166,8 @@ namespace WarcraftLegacies.Source.Setup.Spells
           KillEffect = @"Abilities\Spells\Undead\DeathPact\DeathPactTarget.mdl",
           HealEffect = @"Abilities\Spells\Human\Heal\HealTarget.mdl",
           HealthRestorePercent = 1.5f,
-          ManaRestorePercent = 0.20f
+          ManaRestorePercent = 0.20f,
+        
         };
 
         SpellSystem.Register(deathPactarthas);
@@ -177,11 +178,12 @@ namespace WarcraftLegacies.Source.Setup.Spells
           Radius = 900.0f,
           KillEffect = @"Abilities\Spells\Undead\DarkRitual\DarkRitualTarget.mdl",
           HealEffect = @"Abilities\Spells\Undead\ReplenishMana\SpiritTouchTarget.mdl",
-          HealthRestorePercent = 0.25f, 
-          ManaRestorePercent = 0.36f 
+          HealthRestorePercent = 0.25f,
+          ManaRestorePercent = 0.36f,
         };
 
         SpellSystem.Register(darkRitual);
+
       }
 
       

--- a/src/WarcraftLegacies.Source/Spells/DeathPact.cs
+++ b/src/WarcraftLegacies.Source/Spells/DeathPact.cs
@@ -4,112 +4,111 @@ using MacroTools.Extensions;
 using MacroTools.Libraries;
 using MacroTools.SpellSystem;
 using MacroTools.Utils;
+using WCSharp.Shared;
 using WCSharp.Shared.Data;
 
 namespace WarcraftLegacies.Source.Spells
 {
   /// <summary>
-  /// Kills an allied unit to heal the caster for 125% of the unit's hit points and restores the caster's mana
-  /// by 10% of the unit's hit points.
+  /// Kills an allied unit to heal the caster for a percentage of the unit's hit points
+  /// and restores the caster's mana by a percentage of the unit's hit points.
   /// </summary>
   public sealed class DeathPact : Spell
   {
-    /// <summary>The radius within which the allied unit can be targeted.</summary>
     public float Radius { get; init; }
-
-    /// <summary>The effect applied to the targeted unit when it is killed.</summary>
     public string KillEffect { get; init; } = string.Empty;
-
-    /// <summary>The effect applied to the caster when they are healed.</summary>
     public string HealEffect { get; init; } = string.Empty;
-
-    /// <summary>The percentage of the target unit's health that is restored to the caster.</summary>
     public float HealthRestorePercent { get; init; } = 1.25f;
-
-    /// <summary>The percentage of the target unit's health used to restore the caster's mana.</summary>
     public float ManaRestorePercent { get; init; } = 0.10f;
 
-    /// <inheritdoc />
-    public DeathPact(int id) : base(id)
-    {
-    }
+    public DeathPact(int id) : base(id) { }
 
-    /// <inheritdoc />
     public override void OnCast(unit caster, unit target, Point targetPoint)
     {
-        try
+      try
+      {
+        var casterPlayer = caster.OwningPlayer();
+        var casterPosition = caster.GetPosition();
+
+        var unitsInRange = GlobalGroup
+            .EnumUnitsInRange(casterPosition, Radius)
+            .Where(x => x != null && UnitAlive(x) && IsValidTarget(x, casterPlayer))
+            .ToList();
+
+        if (unitsInRange.Count == 0)
         {
-            var casterPlayer = caster.OwningPlayer();
-            var casterPosition = caster.GetPosition();
-
-          
-            var unitsInRange = GlobalGroup
-                .EnumUnitsInRange(casterPosition, Radius)
-                .Where(x => x != null && UnitAlive(x) && IsValidTarget(x, casterPlayer))
-                .ToList();
-            
-            if (unitsInRange.Count == 0)
-            {
-                return;
-            }
-            
-            var targetUnit = unitsInRange
-                .OrderByDescending(x => IsUnitType(x, UNIT_TYPE_SUMMONED)) 
-                .ThenByDescending(x => IsUnitType(x, UNIT_TYPE_SUMMONED) ? GetUnitLevel(x) : 0)
-                .ThenBy(x => GetUnitLevel(x))
-                .ThenBy(x => MathEx.GetDistanceBetweenPoints(x.GetPosition(), casterPosition))
-                .FirstOrDefault();
-
-          
-            if (targetUnit == null || !UnitAlive(targetUnit))
-            {
-                return;
-            }
-
-            var targetHealth = GetUnitState(targetUnit, UNIT_STATE_LIFE);
-            if (targetHealth <= 0)
-            {
-                return;
-            }
-
-          
-            targetUnit.Kill();
-
-            var healthToRestore = targetHealth * HealthRestorePercent;
-            caster.Heal(healthToRestore);
-
-            if (!string.IsNullOrEmpty(HealEffect))
-            {
-                var casterEffect = AddSpecialEffectTarget(HealEffect, caster, "origin");
-                casterEffect.SetLifespan();
-            }
-
-            var manaToRestore = targetHealth * ManaRestorePercent;
-            var maxMana = GetUnitState(caster, UNIT_STATE_MAX_MANA);
-            var currentMana = GetUnitState(caster, UNIT_STATE_MANA);
-
-            SetUnitState(caster, UNIT_STATE_MANA, Math.Min(currentMana + manaToRestore, maxMana));
-
-            
-            AddSpecialEffect(KillEffect, targetUnit.GetPosition().X, targetUnit.GetPosition().Y)
-                .SetLifespan();
+          Console.WriteLine($"[DeathPact DEBUG] No valid units to sacrifice within radius {Radius}.");
+          return;
         }
-        catch (Exception)
-        {}
+
+        var targetUnit = unitsInRange
+            .OrderByDescending(x => IsUnitType(x, UNIT_TYPE_SUMMONED))
+            .ThenByDescending(x => IsUnitType(x, UNIT_TYPE_SUMMONED) ? GetUnitLevel(x) : 0)
+            .ThenBy(x => GetUnitLevel(x))
+            .ThenBy(x => MathEx.GetDistanceBetweenPoints(x.GetPosition(), casterPosition))
+            .FirstOrDefault();
+
+        if (targetUnit == null || !UnitAlive(targetUnit))
+        {
+          Console.WriteLine("[DeathPact DEBUG] Target unit is null or dead after selection.");
+          return;
+        }
+
+        var targetHealth = GetUnitState(targetUnit, UNIT_STATE_LIFE);
+        if (targetHealth <= 0)
+        {
+          Console.WriteLine($"[DeathPact DEBUG] Target unit '{targetUnit.GetName()}' has no health.");
+          return;
+        }
+
+        Console.WriteLine($"[DeathPact DEBUG] Sacrificing unit '{targetUnit.GetName()}' with {targetHealth} HP.");
+
+        targetUnit.Kill();
+
+        var healthToRestore = targetHealth * HealthRestorePercent;
+        caster.Heal(healthToRestore);
+
+        Console.WriteLine($"[DeathPact DEBUG] Healed caster '{caster.GetName()}' for {healthToRestore} HP.");
+
+        if (!string.IsNullOrEmpty(HealEffect))
+        {
+          var casterEffect = AddSpecialEffectTarget(HealEffect, caster, "origin");
+          casterEffect.SetLifespan();
+        }
+
+        var manaToRestore = targetHealth * ManaRestorePercent;
+
+        Delay.Add(() =>
+        {
+          var currentMana = GetUnitState(caster, UNIT_STATE_MANA);
+          var maxMana = GetUnitState(caster, UNIT_STATE_MAX_MANA);
+          var restoredMana = Math.Min(currentMana + manaToRestore, maxMana);
+          SetUnitState(caster, UNIT_STATE_MANA, restoredMana);
+
+          Console.WriteLine($"[DeathPact DEBUG] [DELAYED] Restored {manaToRestore} mana to caster '{caster.GetName()}'. " +
+                            $"Current: {currentMana} → Final: {restoredMana}");
+
+          GetExpiredTimer().Destroy();
+        });
+
+        AddSpecialEffect(KillEffect, targetUnit.GetPosition().X, targetUnit.GetPosition().Y).SetLifespan();
+      }
+      catch (Exception e)
+      {
+        Console.WriteLine($"[DeathPact ERROR] {e.Message}");
+      }
     }
 
     private static bool IsValidTarget(unit target, player casterPlayer)
     {
-        if (target == null)
-            return false;
-
-        return UnitAlive(target) &&
-               target.OwningPlayer() == casterPlayer &&
-               !target.IsResistant() &&
-               !IsUnitType(target, UNIT_TYPE_STRUCTURE) &&
-               !IsUnitType(target, UNIT_TYPE_ANCIENT) &&
-               !IsUnitType(target, UNIT_TYPE_MECHANICAL) &&
-               !IsUnitType(target, UNIT_TYPE_MAGIC_IMMUNE);
+      return target != null &&
+             UnitAlive(target) &&
+             target.OwningPlayer() == casterPlayer &&
+             !target.IsResistant() &&
+             !IsUnitType(target, UNIT_TYPE_STRUCTURE) &&
+             !IsUnitType(target, UNIT_TYPE_ANCIENT) &&
+             !IsUnitType(target, UNIT_TYPE_MECHANICAL) &&
+             !IsUnitType(target, UNIT_TYPE_MAGIC_IMMUNE);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Spells/DeathPact.cs
+++ b/src/WarcraftLegacies.Source/Spells/DeathPact.cs
@@ -18,8 +18,8 @@ namespace WarcraftLegacies.Source.Spells
     public float Radius { get; init; }
     public string KillEffect { get; init; } = string.Empty;
     public string HealEffect { get; init; } = string.Empty;
-    public float HealthRestorePercent { get; init; } = 1.25f;
-    public float ManaRestorePercent { get; init; } = 0.10f;
+    public float HealthRestorePercent { get; init; }
+    public float ManaRestorePercent { get; init; }
 
     public DeathPact(int id) : base(id) { }
 
@@ -36,10 +36,7 @@ namespace WarcraftLegacies.Source.Spells
             .ToList();
 
         if (unitsInRange.Count == 0)
-        {
-          Console.WriteLine($"[DeathPact DEBUG] No valid units to sacrifice within radius {Radius}.");
           return;
-        }
 
         var targetUnit = unitsInRange
             .OrderByDescending(x => IsUnitType(x, UNIT_TYPE_SUMMONED))
@@ -49,26 +46,16 @@ namespace WarcraftLegacies.Source.Spells
             .FirstOrDefault();
 
         if (targetUnit == null || !UnitAlive(targetUnit))
-        {
-          Console.WriteLine("[DeathPact DEBUG] Target unit is null or dead after selection.");
           return;
-        }
 
         var targetHealth = GetUnitState(targetUnit, UNIT_STATE_LIFE);
         if (targetHealth <= 0)
-        {
-          Console.WriteLine($"[DeathPact DEBUG] Target unit '{targetUnit.GetName()}' has no health.");
           return;
-        }
-
-        Console.WriteLine($"[DeathPact DEBUG] Sacrificing unit '{targetUnit.GetName()}' with {targetHealth} HP.");
 
         targetUnit.Kill();
 
         var healthToRestore = targetHealth * HealthRestorePercent;
         caster.Heal(healthToRestore);
-
-        Console.WriteLine($"[DeathPact DEBUG] Healed caster '{caster.GetName()}' for {healthToRestore} HP.");
 
         if (!string.IsNullOrEmpty(HealEffect))
         {
@@ -84,19 +71,12 @@ namespace WarcraftLegacies.Source.Spells
           var maxMana = GetUnitState(caster, UNIT_STATE_MAX_MANA);
           var restoredMana = Math.Min(currentMana + manaToRestore, maxMana);
           SetUnitState(caster, UNIT_STATE_MANA, restoredMana);
-
-          Console.WriteLine($"[DeathPact DEBUG] [DELAYED] Restored {manaToRestore} mana to caster '{caster.GetName()}'. " +
-                            $"Current: {currentMana} → Final: {restoredMana}");
-
           GetExpiredTimer().Destroy();
         });
 
         AddSpecialEffect(KillEffect, targetUnit.GetPosition().X, targetUnit.GetPosition().Y).SetLifespan();
       }
-      catch (Exception e)
-      {
-        Console.WriteLine($"[DeathPact ERROR] {e.Message}");
-      }
+      catch (Exception) { }
     }
 
     private static bool IsValidTarget(unit target, player casterPlayer)


### PR DESCRIPTION
## Death Pact/Dark Ritual Fix

- Added a delay timer on mana restore to prevent a bug where the blizzard damage system would detect the units "max mana" and calculate the new total before the cost of the ability was deducted. 
- Tooltips updated/corrected 