### PR TITLE
Technopig/CommandSystemUpdate

### DIFF
--- a/src/MacroTools/Commands/Cam.cs
+++ b/src/MacroTools/Commands/Cam.cs
@@ -20,14 +20,14 @@ namespace MacroTools.Commands
     public override CommandType Type => CommandType.Normal;
 
     /// <inheritdoc />
-    public override string Description => "Sets your camera zoom to a specified distance (numeric or preset: 'near', 'medium', 'far').";
+    public override string Description =>
+      "Sets your camera zoom to a specified distance (number between 700–2701 or presets like 'near', 'medium', 'far').";
 
     /// <inheritdoc />
     public override string Execute(player commandUser, params string[] parameters)
     {
       var input = parameters[0].ToLowerInvariant();
 
-      // Preset mappings
       int? parsedHeight = input switch
       {
         "near" => 1000,
@@ -37,7 +37,7 @@ namespace MacroTools.Commands
       };
 
       if (parsedHeight is null)
-        return "Invalid parameter. Use a number between 700–2701 or presets like 'near', 'medium', or 'far'.";
+        return "Invalid parameter. Please use a number between 700 and 2701, or one of the presets: 'near', 'medium', 'far'.";
 
       PlayerData.ByHandle(commandUser).UpdatePlayerSetting("CamDistance", parsedHeight.Value);
       return $"Setting camera height to {parsedHeight.Value}.";

--- a/src/MacroTools/Commands/Cam.cs
+++ b/src/MacroTools/Commands/Cam.cs
@@ -6,7 +6,7 @@ using static War3Api.Common;
 namespace MacroTools.Commands
 {
   /// <summary>
-  /// A <see cref="CommandSystem.Command"/> that sets the player's camera to a specific height.
+  /// A <see cref="CommandSystem.Command"/> that sets the player's camera to a specific height or preset.
   /// </summary>
   public sealed class Cam : Command
   {
@@ -20,18 +20,27 @@ namespace MacroTools.Commands
     public override CommandType Type => CommandType.Normal;
 
     /// <inheritdoc />
-    public override string Description => "Sets your camera zoom to the specified distance.";
+    public override string Description => "Sets your camera zoom to a specified distance (numeric or preset: 'near', 'medium', 'far').";
 
     /// <inheritdoc />
     public override string Execute(player commandUser, params string[] parameters)
     {
-      var cameraHeight = parameters[0];
-      if (!int.TryParse(cameraHeight, out var cameraHeightInt))
-        return "You must specify a number as the first parameter.";
-      
-      cameraHeightInt = Math.Clamp(cameraHeightInt, 700, 2701);
-      PlayerData.ByHandle(commandUser).UpdatePlayerSetting("CamDistance", cameraHeightInt);
-      return $"Setting camera height to {cameraHeightInt}.";
+      var input = parameters[0].ToLowerInvariant();
+
+      // Preset mappings
+      int? parsedHeight = input switch
+      {
+        "near" => 1000,
+        "medium" => 1700,
+        "far" => 2400,
+        _ => int.TryParse(input, out var h) ? Math.Clamp(h, 700, 2701) : null
+      };
+
+      if (parsedHeight is null)
+        return "Invalid parameter. Use a number between 700–2701 or presets like 'near', 'medium', or 'far'.";
+
+      PlayerData.ByHandle(commandUser).UpdatePlayerSetting("CamDistance", parsedHeight.Value);
+      return $"Setting camera height to {parsedHeight.Value}.";
     }
   }
 }

--- a/src/MacroTools/Commands/Captions.cs
+++ b/src/MacroTools/Commands/Captions.cs
@@ -5,7 +5,7 @@ using static War3Api.Common;
 namespace MacroTools.Commands
 {
   /// <summary>
-  /// A <see cref="CommandSystem.Command"/> That turns dialogue captions on or off.
+  /// A <see cref="CommandSystem.Command"/> that turns dialogue captions on or off.
   /// </summary>
   public sealed class Captions : Command
   {
@@ -19,17 +19,24 @@ namespace MacroTools.Commands
     public override CommandType Type => CommandType.Normal;
 
     /// <inheritdoc />
-    public override string Description => "Turns dialogue captions on or off.";
+    public override string Description => "Turns dialogue captions on or off (accepts 'true', 'false', 'on', 'off').";
 
     /// <inheritdoc />
     public override string Execute(player commandUser, params string[] parameters)
     {
-      var captions = parameters[0];
-      if (!bool.TryParse(captions, out var captionsBool))
-        return "You must specify either true or false as the first parameter.";
-      
-      PlayerData.ByHandle(commandUser).UpdatePlayerSetting("ShowCaptions", captionsBool);
-      return $"Setting show captions option to {captionsBool}.";
+      var input = parameters[0].ToLowerInvariant();
+      bool? parsed = input switch
+      {
+        "true" or "on" => true,
+        "false" or "off" => false,
+        _ => null
+      };
+
+      if (parsed is null)
+        return "Invalid parameter. Please use 'true', 'false', 'on', or 'off'.";
+
+      PlayerData.ByHandle(commandUser).UpdatePlayerSetting("ShowCaptions", parsed.Value);
+      return $"Setting show captions option to {parsed.Value}.";
     }
   }
 }

--- a/src/MacroTools/Commands/Dialogue.cs
+++ b/src/MacroTools/Commands/Dialogue.cs
@@ -5,7 +5,7 @@ using static War3Api.Common;
 namespace MacroTools.Commands
 {
   /// <summary>
-  /// A <see cref="CommandSystem.Command"/> That turns dialogue sound on or off.
+  /// A <see cref="CommandSystem.Command"/> that turns dialogue sound on or off.
   /// </summary>
   public sealed class Dialogue : Command
   {
@@ -19,17 +19,24 @@ namespace MacroTools.Commands
     public override CommandType Type => CommandType.Normal;
 
     /// <inheritdoc />
-    public override string Description => "Turns dialogue sound on or off.";
+    public override string Description => "Turns dialogue sound on or off (accepts 'true', 'false', 'on', 'off').";
 
     /// <inheritdoc />
     public override string Execute(player commandUser, params string[] parameters)
     {
-      var dialogue = parameters[0];
-      if (!bool.TryParse(dialogue, out var dialogueBool))
-        return "You must specify either true or false as the first parameter.";
-      
-      PlayerData.ByHandle(commandUser).UpdatePlayerSetting("PlayDialogue", dialogueBool);
-      return $"Setting play dialogue option to {dialogueBool}.";
+      var input = parameters[0].ToLowerInvariant();
+      bool? parsed = input switch
+      {
+        "true" or "on" => true,
+        "false" or "off" => false,
+        _ => null
+      };
+
+      if (parsed is null)
+        return "Invalid parameter. Please use 'true', 'false', 'on', or 'off'.";
+
+      PlayerData.ByHandle(commandUser).UpdatePlayerSetting("PlayDialogue", parsed.Value);
+      return $"Setting play dialogue option to {parsed.Value}.";
     }
   }
 }

--- a/src/MacroTools/Commands/QuestText.cs
+++ b/src/MacroTools/Commands/QuestText.cs
@@ -19,17 +19,24 @@ namespace MacroTools.Commands
     public override CommandType Type => CommandType.Normal;
 
     /// <inheritdoc />
-    public override string Description => "Turns quest text on or off.";
+    public override string Description => "Turns quest text on or off (accepts 'true', 'false', 'on', 'off').";
 
     /// <inheritdoc />
     public override string Execute(player commandUser, params string[] parameters)
     {
-      var questText = parameters[0];
-      if (!bool.TryParse(questText, out var questTextBool))
-        return "You must specify either true or false as the first parameter.";
-      
-      PlayerData.ByHandle(commandUser).UpdatePlayerSetting("ShowQuestText", questTextBool);
-      return $"Setting show quest text option to {questTextBool}.";
+      var input = parameters[0].ToLowerInvariant();
+      bool? parsed = input switch
+      {
+        "true" or "on" => true,
+        "false" or "off" => false,
+        _ => null
+      };
+
+      if (parsed is null)
+        return "Invalid parameter. Please use 'true', 'false', 'on', or 'off'.";
+
+      PlayerData.ByHandle(commandUser).UpdatePlayerSetting("ShowQuestText", parsed.Value);
+      return $"Setting show quest text option to {parsed.Value}.";
     }
   }
 }

--- a/src/MacroTools/Commands/Share.cs
+++ b/src/MacroTools/Commands/Share.cs
@@ -5,25 +5,19 @@ using static War3Api.Common;
 
 namespace MacroTools.Commands
 {
-  /// <summary>Share control of your units with another player.</summary>
-  public sealed class Share : Command
+  /// <summary>
+  /// Removes shared unit control from another faction or all allied factions.
+  /// </summary>
+  public sealed class Unshare : Command
   {
-    /// <inheritdoc />
-    public override string CommandText => "share";
-
-    /// <inheritdoc />
+    public override string CommandText => "unshare";
     public override ExpectedParameterCount ExpectedParameterCount => new(0, 1);
-
-    /// <inheritdoc />
     public override CommandType Type => CommandType.Normal;
+    public override string Description => "Removes shared unit control from a faction or all factions on your team.";
 
-    /// <inheritdoc />
-    public override string Description => "Share control of your units with another faction.";
-
-    /// <inheritdoc />
-    public override string Execute(player cheater, params string[] parameters)
+    public override string Execute(player commandUser, params string[] parameters)
     {
-      var cheaterTeam = cheater.GetTeam();
+      var commandUserTeam = commandUser.GetTeam();
 
       if (parameters.Length >= 1 && parameters[0].ToLower() == "all")
       {
@@ -31,13 +25,13 @@ namespace MacroTools.Commands
 
         foreach (var faction in factions)
         {
-          if (faction.Player != null && faction.Player.GetTeam() == cheaterTeam)
+          if (faction.Player != null && faction.Player.GetTeam() == commandUserTeam)
           {
-            SetPlayerAlliance(cheater, faction.Player, ALLIANCE_SHARED_CONTROL, true);
+            SetPlayerAlliance(commandUser, faction.Player, ALLIANCE_SHARED_CONTROL, false);
           }
         }
 
-        return "Shared control with all factions on your team.";
+        return "Removed shared control from all factions on your team.";
       }
 
       if (!FactionManager.TryGetFactionByName(parameters[0], out var targetFaction))
@@ -46,12 +40,12 @@ namespace MacroTools.Commands
       if (targetFaction.Player == null)
         return $"There is nobody playing the {targetFaction.Name} faction.";
 
-      if (cheaterTeam != targetFaction.Player.GetTeam())
-        return $"{targetFaction.Name} isn't on your team, so you can't share control with them.";
+      if (commandUserTeam != targetFaction.Player.GetTeam())
+        return $"{targetFaction.Name} isn't on your team, so you can't unshare control with them.";
 
-      SetPlayerAlliance(cheater, targetFaction.Player, ALLIANCE_SHARED_CONTROL, true);
+      SetPlayerAlliance(commandUser, targetFaction.Player, ALLIANCE_SHARED_CONTROL, false);
 
-      return $"Shared control with {targetFaction.Name}.";
+      return $"Removed shared control from {targetFaction.Name}.";
     }
   }
 }

--- a/src/MacroTools/Commands/Share.cs
+++ b/src/MacroTools/Commands/Share.cs
@@ -6,18 +6,26 @@ using static War3Api.Common;
 namespace MacroTools.Commands
 {
   /// <summary>
-  /// Share control of your units with another player or all allied factions.
+  /// Share control of your units with another player.
   /// </summary>
   public sealed class Share : Command
   {
+    /// <inheritdoc />
     public override string CommandText => "share";
-    public override ExpectedParameterCount ExpectedParameterCount => new(0, 1);
-    public override CommandType Type => CommandType.Normal;
-    public override string Description => "Share control of your units with another faction or all allied factions.";
 
-    public override string Execute(player commandUser, params string[] parameters)
+    /// <inheritdoc />
+    public override ExpectedParameterCount ExpectedParameterCount => new(0, 1);
+
+    /// <inheritdoc />
+    public override CommandType Type => CommandType.Normal;
+
+    /// <inheritdoc />
+    public override string Description => "Share control of your units with another faction.";
+
+    /// <inheritdoc />
+    public override string Execute(player cheater, params string[] parameters)
     {
-      var commandUserTeam = commandUser.GetTeam();
+      var cheaterTeam = cheater.GetTeam();
 
       if (parameters.Length >= 1 && parameters[0].ToLower() == "all")
       {
@@ -25,9 +33,9 @@ namespace MacroTools.Commands
 
         foreach (var faction in factions)
         {
-          if (faction.Player != null && faction.Player.GetTeam() == commandUserTeam)
+          if (faction.Player != null && faction.Player.GetTeam() == cheaterTeam)
           {
-            SetPlayerAlliance(commandUser, faction.Player, ALLIANCE_SHARED_CONTROL, true);
+            SetPlayerAlliance(cheater, faction.Player, ALLIANCE_SHARED_CONTROL, true);
           }
         }
 
@@ -40,10 +48,11 @@ namespace MacroTools.Commands
       if (targetFaction.Player == null)
         return $"There is nobody playing the {targetFaction.Name} faction.";
 
-      if (commandUserTeam != targetFaction.Player.GetTeam())
+      if (cheaterTeam != targetFaction.Player.GetTeam())
         return $"{targetFaction.Name} isn't on your team, so you can't share control with them.";
 
-      SetPlayerAlliance(commandUser, targetFaction.Player, ALLIANCE_SHARED_CONTROL, true);
+      SetPlayerAlliance(cheater, targetFaction.Player, ALLIANCE_SHARED_CONTROL, true);
+
       return $"Shared control with {targetFaction.Name}.";
     }
   }

--- a/src/MacroTools/Commands/Text.cs
+++ b/src/MacroTools/Commands/Text.cs
@@ -1,0 +1,39 @@
+﻿using MacroTools.CommandSystem;
+using MacroTools.Extensions;
+using static War3Api.Common;
+
+namespace MacroTools.Commands
+{
+  /// <summary>
+  /// Toggles quest text, dialogue, and captions simultaneously.
+  /// </summary>
+  public sealed class Text : Command
+  {
+    public override string CommandText => "text";
+    public override ExpectedParameterCount ExpectedParameterCount => new(1);
+    public override CommandType Type => CommandType.Normal;
+    public override string Description =>
+      "Toggles quest text, dialogue, and captions with a single command (use 'on', 'off', 'true', 'false').";
+
+    public override string Execute(player commandUser, params string[] parameters)
+    {
+      var input = parameters[0].ToLowerInvariant();
+      bool? parsed = input switch
+      {
+        "true" or "on" => true,
+        "false" or "off" => false,
+        _ => null
+      };
+
+      if (parsed is null)
+        return "Invalid input. Use 'on', 'off', 'true', or 'false'.";
+
+      var data = PlayerData.ByHandle(commandUser);
+      data.UpdatePlayerSetting("ShowQuestText", parsed.Value);
+      data.UpdatePlayerSetting("PlayDialogue", parsed.Value);
+      data.UpdatePlayerSetting("ShowCaptions", parsed.Value);
+
+      return $"All text settings set to {parsed.Value}.";
+    }
+  }
+}

--- a/src/MacroTools/Commands/Unshare.cs
+++ b/src/MacroTools/Commands/Unshare.cs
@@ -6,14 +6,14 @@ using static War3Api.Common;
 namespace MacroTools.Commands
 {
   /// <summary>
-  /// Share control of your units with another player or all allied factions.
+  /// Removes shared unit control from another faction or all allied factions.
   /// </summary>
-  public sealed class Share : Command
+  public sealed class Unshare : Command
   {
-    public override string CommandText => "share";
+    public override string CommandText => "unshare";
     public override ExpectedParameterCount ExpectedParameterCount => new(0, 1);
     public override CommandType Type => CommandType.Normal;
-    public override string Description => "Share control of your units with another faction or all allied factions.";
+    public override string Description => "Removes shared unit control from a faction or all factions on your team.";
 
     public override string Execute(player commandUser, params string[] parameters)
     {
@@ -27,11 +27,11 @@ namespace MacroTools.Commands
         {
           if (faction.Player != null && faction.Player.GetTeam() == commandUserTeam)
           {
-            SetPlayerAlliance(commandUser, faction.Player, ALLIANCE_SHARED_CONTROL, true);
+            SetPlayerAlliance(commandUser, faction.Player, ALLIANCE_SHARED_CONTROL, false);
           }
         }
 
-        return "Shared control with all factions on your team.";
+        return "Removed shared control from all factions on your team.";
       }
 
       if (!FactionManager.TryGetFactionByName(parameters[0], out var targetFaction))
@@ -41,10 +41,11 @@ namespace MacroTools.Commands
         return $"There is nobody playing the {targetFaction.Name} faction.";
 
       if (commandUserTeam != targetFaction.Player.GetTeam())
-        return $"{targetFaction.Name} isn't on your team, so you can't share control with them.";
+        return $"{targetFaction.Name} isn't on your team, so you can't unshare control with them.";
 
-      SetPlayerAlliance(commandUser, targetFaction.Player, ALLIANCE_SHARED_CONTROL, true);
-      return $"Shared control with {targetFaction.Name}.";
+      SetPlayerAlliance(commandUser, targetFaction.Player, ALLIANCE_SHARED_CONTROL, false);
+
+      return $"Removed shared control from {targetFaction.Name}.";
     }
   }
 }

--- a/src/MacroTools/QuestSystem/FactionQuestExtensions.cs
+++ b/src/MacroTools/QuestSystem/FactionQuestExtensions.cs
@@ -20,7 +20,7 @@ namespace MacroTools.QuestSystem
       
       foreach (var enumPlayer in WCSharp.Shared.Util.EnumeratePlayers())
         if (enumPlayer != whichPlayer)
-          if (PlayerData.ByHandle(whichPlayer).PlayerSettings.ShowQuestText)
+          if (PlayerData.ByHandle(enumPlayer).PlayerSettings.ShowQuestText)
             DisplayTextToPlayer(enumPlayer, 0, 0,
               $"\n|cffffcc00MAJOR EVENT - {whichPlayer.GetFaction()?.PrefixCol}{questData.Title}|r\n{questData.RewardFlavour}\n");
     }

--- a/src/MacroTools/Save/PlayerSettings.cs
+++ b/src/MacroTools/Save/PlayerSettings.cs
@@ -13,10 +13,10 @@ namespace MacroTools.Save
       set => _camDistance = Math.Clamp(value, 700, 2701);
     }
     
-    internal bool ShowQuestText { get; set; } = true;
+    public bool ShowQuestText { get; set; } = true;
     
-    internal bool PlayDialogue { get; set; } = true;
+    public bool PlayDialogue { get; set; } = true;
     
-    internal bool ShowCaptions { get; set; } = true;
+    public bool ShowCaptions { get; set; } = true;
   }
 }

--- a/src/MacroTools/Save/SaveManager.cs
+++ b/src/MacroTools/Save/SaveManager.cs
@@ -14,7 +14,7 @@ namespace MacroTools.Save
   {
     internal static Dictionary<player, PlayerSettings> SavesByPlayer { get; } = new();
     private static SaveSystem<PlayerSettings>? _saveSystem;
-	
+
     public static void Initialize()
     {
       _saveSystem = new SaveSystem<PlayerSettings>(new SaveSystemOptions
@@ -45,8 +45,12 @@ namespace MacroTools.Save
         save.PlayDialogue = true;
         save.ShowCaptions = true;
       }
+
       save.GetPlayer().ApplyCameraField(CAMERA_FIELD_TARGET_DISTANCE, save.CamDistance, 1);
-		
+      save.GetPlayer().GetPlayerSettings().ShowQuestText = save.ShowQuestText;
+      save.GetPlayer().GetPlayerSettings().PlayDialogue = save.PlayDialogue;
+      save.GetPlayer().GetPlayerSettings().ShowCaptions = save.ShowCaptions;
+
       // If the load result is anything except success, the save will be a newly created object
       if (loadResult == LoadResult.FailedHash)
       {
@@ -58,7 +62,7 @@ namespace MacroTools.Save
         Console.WriteLine("An existing save failed to load correctly!");
       }
     }
-	
+
     /// <summary>
     /// Saves the player settings for the given player.
     /// </summary>

--- a/src/WarcraftLegacies.Source/Setup/CommandSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/CommandSetup.cs
@@ -16,6 +16,8 @@ namespace WarcraftLegacies.Source.Setup
       commandManager.Register(new Dialogue());
       commandManager.Register(new Settings());
       commandManager.Register(new Share());
+      commandManager.Register(new Unshare());
+      commandManager.Register(new Text());
       commandManager.Register(new GiveGold("givegold"));
       commandManager.Register(new GiveGold("gold"));
       commandManager.Register(new GiveGold("g"));

--- a/src/WarcraftLegacies.Source/Setup/CommandSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/CommandSetup.cs
@@ -1,6 +1,7 @@
 ﻿using MacroTools.Commands;
 using MacroTools.CommandSystem;
 
+
 namespace WarcraftLegacies.Source.Setup
 {
   public static class CommandSetup


### PR DESCRIPTION
## Player Command System Update

- Integrated a fix provided by Aeilol that fixes a bug that prevented the system from saving/loading wc3sharp data locally.
- Added the -unshare all command. 
- Added "on" and "off" as valid strings for Captions, Dialogue, Quest Text, 
- Added near, far. medium commands for -cam.
- Added the Text class , which allows the player to turn all settings on/off at once. 

 

