### PR TITLE
refactor: inline `AddAbility` to avoid shadowing by WCSharp

### DIFF
--- a/src/MacroTools/ControlPointSystem/ControlPointManager.cs
+++ b/src/MacroTools/ControlPointSystem/ControlPointManager.cs
@@ -162,12 +162,12 @@ namespace MacroTools.ControlPointSystem
         RegisterControlLevelChangeTrigger(controlPoint);
         RegisterControlLevelGrowthOverTime(controlPoint);
         ConfigureControlPointStats(controlPoint, true);
-        controlPoint.Unit.AddAbility(IncreaseControlLevelAbilityTypeId);
+        UnitAddAbility(controlPoint.Unit, IncreaseControlLevelAbilityTypeId);
       }
       
       controlPoint.OnRegister();
       if (GetOwningPlayer(controlPoint.Unit) != Player(PLAYER_NEUTRAL_AGGRESSIVE))
-        controlPoint.Unit.AddAbility(RegenerationAbility);
+        UnitAddAbility(controlPoint.Unit, RegenerationAbility);
     }
 
     private static void RegisterIncome(ControlPoint controlPoint)
@@ -217,10 +217,10 @@ namespace MacroTools.ControlPointSystem
           newOwner.BaseIncome += controlPoint.Value;
 
           if (GetUnitAbilityLevel(controlPoint.Unit, RegenerationAbility) == 0)
-            controlPoint.Unit.AddAbility(RegenerationAbility);
+            UnitAddAbility(controlPoint.Unit, RegenerationAbility);
             
           if (GetUnitAbilityLevel(controlPoint.Unit, PiercingResistanceAbility) == 0)
-            controlPoint.Unit.AddAbility(PiercingResistanceAbility);
+            UnitAddAbility(controlPoint.Unit, PiercingResistanceAbility);
             
           controlPoint.Unit.SetLifePercent(100);
           controlPoint.ControlLevel = 0;
@@ -298,7 +298,7 @@ namespace MacroTools.ControlPointSystem
       var defenderUnitTypeId = controlPoint.Owner.GetFaction()?.ControlPointDefenderUnitTypeId ??
                                ControlLevelSettings.DefaultDefenderUnitTypeId;
       controlPoint.Defender ??= CreateUnit(controlPoint.Owner, defenderUnitTypeId, GetUnitX(controlPoint.Unit), GetUnitY(controlPoint.Unit), 270);
-      controlPoint.Defender.AddAbility(FourCC("Aloc"));
+      UnitAddAbility(controlPoint.Defender, FourCC("Aloc"));
       SetUnitInvulnerable(controlPoint.Defender, true);
       ConfigureControlPointOrDefenderAttack(controlPoint.Defender, flooredLevel);
       ConfigureControlPointOrDefenderAttack(controlPoint.Unit, flooredLevel);
@@ -311,8 +311,8 @@ namespace MacroTools.ControlPointSystem
 
       controlPoint.Defender = null;
       SetUnitInvulnerable(controlPoint.Unit, false);
-      controlPoint.Unit
-        .AddAbility(IncreaseControlLevelAbilityTypeId);
+      UnitAddAbility(controlPoint.Unit,
+        IncreaseControlLevelAbilityTypeId);
     }
 
     private void ConfigureControlPointOrDefenderAttack(unit whichUnit, int controlLevel)

--- a/src/MacroTools/DummyCasters/AbilitySpecificDummyCaster.cs
+++ b/src/MacroTools/DummyCasters/AbilitySpecificDummyCaster.cs
@@ -28,7 +28,7 @@ namespace MacroTools.DummyCasters
       var whichPlayer = GetOwningPlayer(caster);
       SetUnitOwner(_unit, whichPlayer, true);
       _unit.SetPosition(originPoint);
-      _unit.AddAbility(_abilityTypeId);
+      UnitAddAbility(_unit, _abilityTypeId);
       SetUnitAbilityLevel(_unit, _abilityTypeId, level);
 
       if (originType == DummyCastOriginType.Caster)
@@ -42,7 +42,7 @@ namespace MacroTools.DummyCasters
       var whichPlayer = GetOwningPlayer(caster);
       SetUnitOwner(_unit, whichPlayer, true);
       _unit.SetPosition(caster.GetPosition());
-      _unit.AddAbility(_abilityTypeId);
+      UnitAddAbility(_unit, _abilityTypeId);
       SetUnitAbilityLevel(_unit, _abilityTypeId, level);
 
       IssueImmediateOrderById(_unit, _abilityOrderId);
@@ -56,7 +56,7 @@ namespace MacroTools.DummyCasters
       var whichPlayer = GetOwningPlayer(caster);
       SetUnitOwner(_unit, whichPlayer, true);
       _unit.SetPosition(target.GetPosition());
-       _unit.AddAbility(_abilityTypeId);
+      UnitAddAbility(_unit, _abilityTypeId);
       SetUnitAbilityLevel(_unit, _abilityTypeId, level);
 
       IssueImmediateOrderById(_unit, _abilityOrderId);
@@ -69,7 +69,7 @@ namespace MacroTools.DummyCasters
     {
       SetUnitOwner(_unit, whichPlayer, true);
       _unit.SetPosition(target);
-      _unit.AddAbility(_abilityTypeId);
+      UnitAddAbility(_unit, _abilityTypeId);
       SetUnitAbilityLevel(_unit, _abilityTypeId, level);
       _unit
         .IssueOrder(_abilityOrderId, target);

--- a/src/MacroTools/DummyCasters/GlobalDummyCaster.cs
+++ b/src/MacroTools/DummyCasters/GlobalDummyCaster.cs
@@ -21,7 +21,7 @@ namespace MacroTools.DummyCasters
       var owningPlayer = GetOwningPlayer(caster);
       SetUnitOwner(_unit, owningPlayer, true);
       _unit.SetPosition(originPoint);
-      _unit.AddAbility(abilId);
+      UnitAddAbility(_unit, abilId);
       SetUnitAbilityLevel(_unit, abilId, level);
 
       if (originType == DummyCastOriginType.Caster)
@@ -36,7 +36,7 @@ namespace MacroTools.DummyCasters
       var owningPlayer = GetOwningPlayer(caster);
       SetUnitOwner(_unit, owningPlayer, true);
       _unit.SetPosition(caster.GetPosition());
-      _unit.AddAbility(abilId);
+      UnitAddAbility(_unit, abilId);
       SetUnitAbilityLevel(_unit, abilId, level);
 
       IssueImmediateOrderById(_unit, orderId);
@@ -51,7 +51,7 @@ namespace MacroTools.DummyCasters
       var owningPlayer = GetOwningPlayer(caster);
       SetUnitOwner(_unit, owningPlayer, true);
       _unit.SetPosition(target.GetPosition());
-      _unit.AddAbility(abilId);
+      UnitAddAbility(_unit, abilId);
       SetUnitAbilityLevel(_unit, abilId, level);
 
       IssueImmediateOrderById(_unit, orderId);
@@ -65,7 +65,7 @@ namespace MacroTools.DummyCasters
     {
       SetUnitOwner(_unit, whichPlayer, true);
       _unit.SetPosition(target);
-      _unit.AddAbility(abilId);
+      UnitAddAbility(_unit, abilId);
       SetUnitAbilityLevel(_unit, abilId, level);
       _unit.IssueOrder(orderId, target);
       UnitRemoveAbility(_unit, abilId);

--- a/src/MacroTools/DummyCasters/LongLivedDummyCaster.cs
+++ b/src/MacroTools/DummyCasters/LongLivedDummyCaster.cs
@@ -19,7 +19,7 @@ namespace MacroTools.DummyCasters
     public void ChannelOnPoint(unit caster, int abilityId, string orderId, int level, Point targetPoint, float duration)
     {
       var newUnit = CreateUnit(GetOwningPlayer(caster), _unitTypeId, targetPoint.X, targetPoint.Y, 0);
-      newUnit.AddAbility(abilityId);
+      UnitAddAbility(newUnit, abilityId);
       SetUnitAbilityLevel(newUnit, abilityId, level);
       IssueImmediateOrder(newUnit, orderId);
       newUnit.SetTimedLife(duration);
@@ -31,7 +31,7 @@ namespace MacroTools.DummyCasters
     public void ChannelAtCaster(unit caster, int abilityId, string orderId, int level, float duration)
     {
       var newUnit = CreateUnit(GetOwningPlayer(caster), _unitTypeId, caster.GetPosition().X, caster.GetPosition().Y, 0);
-      newUnit.AddAbility(abilityId);
+      UnitAddAbility(newUnit, abilityId);
       SetUnitAbilityLevel(newUnit, abilityId, level);
       IssueImmediateOrder(newUnit, orderId);
       newUnit.SetTimedLife(duration);

--- a/src/MacroTools/Extensions/UnitExtensions.cs
+++ b/src/MacroTools/Extensions/UnitExtensions.cs
@@ -351,15 +351,6 @@ namespace MacroTools.Extensions
     }
 
     /// <summary>
-    /// Adds an ability to the unit.
-    /// </summary>
-    public static void AddAbility(this unit whichUnit, int abilityTypeId)
-    {
-      UnitAddAbility(whichUnit, abilityTypeId);
-      UnitMakeAbilityPermanent(whichUnit, true, abilityTypeId);
-    }
-
-    /// <summary>
     /// Causes the specified unit to become capturable,
     /// such that it changes ownership to the attacker when reduced below 0 hit points.
     /// </summary>

--- a/src/MacroTools/Mechanics/DemonGates/DemonGateBuff.cs
+++ b/src/MacroTools/Mechanics/DemonGates/DemonGateBuff.cs
@@ -87,7 +87,7 @@ namespace MacroTools.Mechanics.DemonGates
     {
       Target.IssueOrder(OrderId("setrally"), Target.GetPosition());
       BlzSetUnitMaxMana(Target, (int)_spawnInterval);
-      Target.AddAbility(_toggleAbilityTypeId);
+      UnitAddAbility(Target, _toggleAbilityTypeId);
       IssueImmediateOrder(Target, "immolation");
       Progress = _spawnInterval / 2;
     }

--- a/src/MacroTools/Powers/CityOfHeroes.cs
+++ b/src/MacroTools/Powers/CityOfHeroes.cs
@@ -59,8 +59,8 @@ namespace MacroTools.Powers
       whichUnit.MultiplyMaxHitpoints(_statMultiplier);
       whichUnit.MultiplyMaxMana(_statMultiplier);
       UnitRemoveAbility(whichUnit, FourCC("Aihn"));
-      whichUnit.AddAbility(HeroGlowAbilityTypeId);
-      whichUnit.AddAbility(FourCC("AInv"));
+      UnitAddAbility(whichUnit, HeroGlowAbilityTypeId);
+      UnitAddAbility(whichUnit, FourCC("AInv"));
       BlzSetUnitIntegerField(whichUnit, UNIT_IF_DEFENSE_TYPE, 5);
 
       if (BlzGetUnitWeaponIntegerField(whichUnit, UNIT_WEAPON_IF_ATTACK_ATTACK_TYPE, 0) != 3)

--- a/src/WarcraftLegacies.Source/ArtifactBehaviour/EyeOfSargerasMissile.cs
+++ b/src/WarcraftLegacies.Source/ArtifactBehaviour/EyeOfSargerasMissile.cs
@@ -36,7 +36,7 @@ namespace WarcraftLegacies.Source.ArtifactBehaviour
       if (!UnitAlive(Target)) 
         return;
 
-      Target.AddAbility(ABILITY_A01Y_INVENTORY_DUMMY_DROP_ARTIFACT);
+      UnitAddAbility(Target, ABILITY_A01Y_INVENTORY_DUMMY_DROP_ARTIFACT);
       Target.AddItemSafe(_eyeOfSargeras);
       _impacted = true;
 

--- a/src/WarcraftLegacies.Source/PassiveAbilities/Incubate/MatureEggBuff.cs
+++ b/src/WarcraftLegacies.Source/PassiveAbilities/Incubate/MatureEggBuff.cs
@@ -23,8 +23,8 @@ namespace WarcraftLegacies.Source.PassiveAbilities.Incubate
     {
       BlzSetUnitName(Target, "Mature Egg");
       SetUnitVertexColor(Target, 255, 255, 255, 255);
-      Target
-        .AddAbility(ABILITY_ZBBS_HATCH_INCUBATE);
+      UnitAddAbility(Target,
+        ABILITY_ZBBS_HATCH_INCUBATE);
 
       var effect = AddSpecialEffect(@"Abilities\Spells\Items\AIem\AIemTarget.mdl", GetUnitX(Target), GetUnitY(Target));
       BlzSetSpecialEffectColor(effect, 0, 255, 0);

--- a/src/WarcraftLegacies.Source/Quests/QuestBookOfMedivh.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestBookOfMedivh.cs
@@ -52,7 +52,7 @@ namespace WarcraftLegacies.Source.Quests
         _bookOfMedivhPedestal = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), UNIT_NBSM_BOOK_OF_MEDIVH,
           bookLocation.Rectangle.Center.X, bookLocation.Rectangle.Center.Y, 270);
         SetUnitInvulnerable(_bookOfMedivhPedestal, true);
-        _bookOfMedivhPedestal.AddAbility(ABILITY_A01Y_INVENTORY_DUMMY_DROP_ARTIFACT);
+        UnitAddAbility(_bookOfMedivhPedestal, ABILITY_A01Y_INVENTORY_DUMMY_DROP_ARTIFACT);
         _bookOfMedivhPedestal.AddItemSafe(bookOfMedivh.Item);
       }
       

--- a/src/WarcraftLegacies.Source/Quests/Scourge/QuestKelthuzadLich.cs
+++ b/src/WarcraftLegacies.Source/Quests/Scourge/QuestKelthuzadLich.cs
@@ -1,5 +1,4 @@
 ﻿using MacroTools.ArtifactSystem;
-using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.LegendSystem;
 using MacroTools.ObjectiveSystem.Objectives.LegendBased;
@@ -64,7 +63,7 @@ namespace WarcraftLegacies.Source.Quests.Scourge
       {
         UnitRemoveAbility(_sunwell.Unit, ABILITY_A0OC_EXTRACT_VIAL_ALL);
         UnitRemoveAbility(_sunwell.Unit, ABILITY_A0EP_SUMMON_GRANITE_GOLEMS_QUEL_THALAS_SUNWELL);
-        _sunwell.Unit.AddAbility(ABILITY_A00D_DESTROY_THE_CORRUPTED_SUNWELL_QUEL_THALAS_SUNWELL);
+        UnitAddAbility(_sunwell.Unit, ABILITY_A00D_DESTROY_THE_CORRUPTED_SUNWELL_QUEL_THALAS_SUNWELL);
         BlzSetUnitMaxMana(_sunwell.Unit, 0);
         BlzSetUnitSkin(_sunwell.Unit, UNIT_N079_THE_SUNWELL_CORRUPTED_QUEL_THALAS_OTHER);
         BlzSetUnitName(_sunwell.Unit, "Corrupted Sunwell");


### PR DESCRIPTION
As per offline conversation, inlines `UnitExtensions.AddAbility` to avoid shadowing caused by [WCSharp's instance member](https://github.com/Orden4/WCSharp/blob/v3.2.2/WCSharp.Api/unit.cs#L356) and removes call to `UnitMakeAbilityPermanent`, as the abilities weren't added to any morphing units.

Relates to: #3373
Relates to: #3385