### PR TITLE
refactor: remove redundant explicit `ToString()` in string interpolation

### DIFF
--- a/src/MacroTools/BookSystem/Core/Page.cs
+++ b/src/MacroTools/BookSystem/Core/Page.cs
@@ -17,7 +17,7 @@ public abstract class Page<TItem, TCard, TCardFactory> : Frame
 
   public int PageNumber
   {
-    set => _pageNumberFrame.Text = $"Page {value.ToString()}";
+    set => _pageNumberFrame.Text = $"Page {value}";
   }
 
   protected Page(float width, float height, int rows, int columns, float yOffsetTop, float yOffsetBot) :

--- a/src/MacroTools/Cheats/CheatQuestProgress.cs
+++ b/src/MacroTools/Cheats/CheatQuestProgress.cs
@@ -23,7 +23,7 @@ public sealed class CheatQuestProgress : Command
   public override CommandType Type => CommandType.Cheat;
 
   /// <inheritdoc />
-  public override string Description => $"Sets the specified quest's progress to {_progress.ToString()} for the specified faction.";
+  public override string Description => $"Sets the specified quest's progress to {_progress} for the specified faction.";
 
   /// <summary>
   /// Initializes a new instance of the <see cref="CheatQuestProgress"/> class.
@@ -61,6 +61,6 @@ public sealed class CheatQuestProgress : Command
     }
 
     quest.Progress = _progress;
-    return $"Set quest progress of {quest.Title} to {_progress.ToString()} for {nameof(Faction)} {faction.Name}.";
+    return $"Set quest progress of {quest.Title} to {_progress} for {nameof(Faction)} {faction.Name}.";
   }
 }


### PR DESCRIPTION
Offers improved codegen, especially for primitive types:

```diff
-        this._pageNumberFrame:setText("Page " .. System.toString(System.Int32.ToString(value)))
+        this._pageNumberFrame:setText("Page " .. value)
```