### PR TITLE
fix: add global using for the `System` namespace

### DIFF
--- a/src/TestMap.Source/Usings.cs
+++ b/src/TestMap.Source/Usings.cs
@@ -1,2 +1,3 @@
-﻿global using WCSharp.Api;
+﻿global using System;
+global using WCSharp.Api;
 global using static WCSharp.Api.Common;


### PR DESCRIPTION
The TestMap has transitive dependencies that enable `ImplicitUsings`. This PR imports the `System` namespace to resolve that

Closes: #3376