### PR TITLE
chore: bump war3net to 6.0.3

### DIFF
--- a/src/War3Api.Object/War3Api.Object.csproj
+++ b/src/War3Api.Object/War3Api.Object.csproj
@@ -14,9 +14,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="WCSharp.War3Net.Build" Version="5.8.0" />
-        <PackageReference Include="WCSharp.War3Net.Build.Core" Version="5.8.0" />
-        <PackageReference Include="War3Net.Common" Version="5.8.0" />
+        <PackageReference Include="War3Net.Build" Version="6.0.3" />
+        <PackageReference Include="War3Net.Build.Core" Version="6.0.3" />
+        <PackageReference Include="War3Net.Common" Version="6.0.2" />
     </ItemGroup>
 
 </Project>

--- a/src/Warcraft.Cartographer/Warcraft.Cartographer.csproj
+++ b/src/Warcraft.Cartographer/Warcraft.Cartographer.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="System.CommandLine" Version="2.0.1"/>
     <PackageReference Include="WCSharp.CSharpLua" Version="6.0.3"/>
     <PackageReference Include="WCSharp.CSharpLua.CoreSystem" Version="6.0.7"/>
-    <PackageReference Include="War3Net.Build" Version="5.8.2"/>
-    <PackageReference Include="War3Net.Build.Core" Version="5.8.2"/>
+    <PackageReference Include="War3Net.Build" Version="6.0.3" />
+    <PackageReference Include="War3Net.Build.Core" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates to the latest version of War3Net that:

* Adds support for dotnet10 (the framework target we use) for improved build performance
* Addresses some long-standing security vulnerabilities in package dependencies (some of these are still transitively included by WCSharp)
* Aligns mapscript semantics with the World Editor's