### PR TITLE
fix: stop double-localizing GetObjectName results

### DIFF
--- a/src/MacroTools/Localization/Loc.cs
+++ b/src/MacroTools/Localization/Loc.cs
@@ -1980,8 +1980,6 @@ public static class Loc
     ["Honor Hold is now free from the constant looming threat of Hellfire Citadel, and have finally been reconnected with their Alliance from Azeroth."] =
       "Bastión del Honor ahora está libre de la constante amenaza latente de la Ciudadela del Fuego Infernal, y finalmente se ha reconectado con su Alianza de Azeroth.",
     ["Hellfire Citadel"] = "Hellfire Citadel",
-    ["Siege Tower"] = "Siege Tower",
-    ["Artillery Bombardment"] = "Artillery Bombardment",
     ["Control of all units at Honor Hold and {siegeTower} gain the {ability} ability."] =
       "Control de todas las unidades en Bastión del Honor y las {siegeTower} obtienen la habilidad {ability}.",
 
@@ -2140,8 +2138,6 @@ public static class Loc
     ["Ny'alotha, the Waking City"] = "Ny'alotha, the Waking City",
     ["Can now train Garrosh from the {altar} and research the Warsong expedition from the {shipyard}"] =
       "Ahora puedes entrenar a Garrosh desde el {altar} e investigar la expedición Warsong desde el {shipyard}",
-    ["Altar of Conquerors"] = "Altar de los Conquistadores",
-    ["Shipyard"] = "Astillero",
 
     // Warsong - QuestGrom
     ["Breaking Bad Blood"] = "Rompiendo la Mala Sangre",
@@ -2183,11 +2179,6 @@ public static class Loc
       "El destino de los ogros ha sido decidido, y el poder de la Horda crece.",
     ["Subdue the Ogres"] = "Someter a los Ogros",
     ["Pillage Stonemaul"] = "Saquear Quebrantarrocas",
-    ["Stonemaul"] = "Stonemaul",
-    ["Warsong Grunt"] = "Warsong Grunt",
-    ["Mok'Nathal Warrior"] = "Mok'Nathal Warrior",
-    ["Blademaster"] = "Blademaster",
-    ["Kor'kron Elite"] = "Kor'kron Elite",
     ["Gain control of Stonemaul, {removeUnit}s' are upgraded to {addUnit}s' and unlock the ability to train {ogreMagi}s. Alternatively, earn {gold} gold and up to {experience} experience points, shared among all your heroes—the fewer heroes you control, the less experience each receives. Additionally, enhance both {blademaster}s' and {korkronElite}s' attack damage by 10, movement speed by 20 and hit points by 250."] =
       "Obtienes control de Quebrantarrocas: los {removeUnit} se mejoran a {addUnit}, y desbloqueas la habilidad de entrenar {ogreMagi}. Alternativamente, gana {gold} de oro y hasta {experience} puntos de experiencia, repartidos entre todos tus héroes —mientras menos héroes controles, menos experiencia recibe cada uno—. Además, mejora el daño de ataque de los {blademaster} y {korkronElite} en 10, la velocidad de movimiento en 20, y los puntos de vida en 250.",
 
@@ -2197,9 +2188,6 @@ public static class Loc
       "Los Tauren de Cima del Trueno son guerreros nobles, pero sus lealtades son inciertas. Tráelos al redil o saquea sus tierras.",
     ["Subdue the Tauren"] = "Someter a los Tauren",
     ["Pillage Thunder Bluff"] = "Saquear Cima del Trueno",
-
-    ["Thunderbluff"] = "Thunderbluff",
-    ["Bloodhoof Totem"] = "Bloodhoof Totem",
     ["Control of Thunder Bluff and the ability to train {kodo}s' from {beastiary} or gain the artifact {totem}, {gold} gold and {experience} experience points, shared across all your heroes—the fewer heroes you control, the less experience each receives."] =
       "Control de Cima del Trueno y la habilidad de entrenar {kodo} desde {beastiary}, o consigue el artefacto {totem}, {gold} de oro y {experience} puntos de experiencia, repartidos entre todos tus héroes —mientras menos héroes controles, menos experiencia recibe cada uno—.",
 
@@ -2210,9 +2198,6 @@ public static class Loc
     ["The Darkspear Trolls have been brought to heel."] = "Los Trolls Lanza Negra han sido sometidos.",
     ["Subdue the Trolls"] = "Someter a los Trolls",
     ["Pillage Echo Isles"] = "Saquear las Islas del Eco",
-    ["Axe Thrower"] = "Axe Thrower",
-    ["Darkspear Berserker"] = "Darkspear Berserker",
-    ["Shadowpriest"] = "Shadowpriest",
     ["Gain control of Echo Isles, {removeUnit}s are upgraded to {addUnit}s and learn to train {shadowpriest}s. Alternatively, earn {gold} gold and up to {experience} experience points, shared among all your heroes—the fewer heroes you control, the less experience each receives. Additionally, enhance both {blademaster}s' and {korkronElite}s' maximum mana by 250 and mana regeneration by 50%."] =
       "Obtienes control de las Islas del Eco: los {removeUnit} se mejoran a {addUnit}, y aprendes a entrenar {shadowpriest}. Alternativamente, ganas {gold} de oro y hasta {experience} puntos de experiencia, repartidos entre todos tus héroes —mientras menos héroes controles, menos experiencia recibe cada uno—. Además, mejora el maná máximo de los {blademaster} y {korkronElite} en 250 y la regeneración de maná en 50%.",
 

--- a/src/WarcraftLegacies.Source/Factions/Stormwind/Quests/QuestHonorHold.cs
+++ b/src/WarcraftLegacies.Source/Factions/Stormwind/Quests/QuestHonorHold.cs
@@ -38,8 +38,8 @@ public sealed class QuestHonorHold : QuestData
   /// <inheritdoc/>
   protected override string RewardDescription => Loc.Format(
     "Control of all units at Honor Hold and {siegeTower} gain the {ability} ability.",
-    ("{siegeTower}", Loc.Get(GetObjectName(UNIT_O06K_SIEGE_TOWER_STORMWIND))),
-    ("{ability}", Loc.Get(GetObjectName(ABILITY_A108_ARTILLERY_BOMBARDMENT_STORMWIND))));
+    ("{siegeTower}", GetObjectName(UNIT_O06K_SIEGE_TOWER_STORMWIND)),
+    ("{ability}", GetObjectName(ABILITY_A108_ARTILLERY_BOMBARDMENT_STORMWIND)));
 
   /// <inheritdoc/>
   protected override void OnFail(Faction completingFaction)

--- a/src/WarcraftLegacies.Source/Factions/Stormwind/Quests/QuestStormwindCity.cs
+++ b/src/WarcraftLegacies.Source/Factions/Stormwind/Quests/QuestStormwindCity.cs
@@ -45,10 +45,10 @@ public sealed class QuestStormwindCity : QuestData
   /// <inheritdoc />
   protected override string RewardDescription => Loc.Format(
     "Gain control of all units in Stormwind, learn to train Varian from the {altar}, learn to cast {summonGarrison} from {keep}s and {castle}s, and acquire the {power} Power",
-    ("{altar}", Loc.Get(GetObjectName(UNIT_H06T_ALTAR_OF_KINGS_STORMWIND_ALTAR))),
-    ("{summonGarrison}", Loc.Get(GetObjectName(ABILITY_A0GD_SUMMON_GARRISON_STORMWIND))),
-    ("{keep}", Loc.Get(GetObjectName(UNIT_H06M_KEEP_STORMWIND_T2))),
-    ("{castle}", Loc.Get(GetObjectName(UNIT_H06N_CASTLE_STORMWIND_T3))),
+    ("{altar}", GetObjectName(UNIT_H06T_ALTAR_OF_KINGS_STORMWIND_ALTAR)),
+    ("{summonGarrison}", GetObjectName(ABILITY_A0GD_SUMMON_GARRISON_STORMWIND)),
+    ("{keep}", GetObjectName(UNIT_H06M_KEEP_STORMWIND_T2)),
+    ("{castle}", GetObjectName(UNIT_H06N_CASTLE_STORMWIND_T3)),
     ("{power}", Loc.Get(RewardPowerName)));
 
   /// <inheritdoc />

--- a/src/WarcraftLegacies.Source/Factions/Warsong/Quests/QuestGarrosh.cs
+++ b/src/WarcraftLegacies.Source/Factions/Warsong/Quests/QuestGarrosh.cs
@@ -15,8 +15,8 @@ public sealed class QuestGarrosh : QuestData
   /// <inheritdoc/>
   protected override string RewardDescription => Loc.Format(
     "Can now train Garrosh from the {altar} and research the Warsong expedition from the {shipyard}",
-    ("{altar}", Loc.Get(GetObjectName(UNIT_O020_ALTAR_OF_CONQUERORS_WARSONG_ALTAR))),
-    ("{shipyard}", Loc.Get(GetObjectName(UNIT_O02T_SHIPYARD_WARSONG_SHIPYARD))));
+    ("{altar}", GetObjectName(UNIT_O020_ALTAR_OF_CONQUERORS_WARSONG_ALTAR)),
+    ("{shipyard}", GetObjectName(UNIT_O02T_SHIPYARD_WARSONG_SHIPYARD)));
 
   public QuestGarrosh() : base("Twilight's Reckoning",
     "The monstrous Old God N'Zoth threatens Kalimdor with madness and ruin. End his terrifying reign to secure the continent and further the Horde's ambitions.",

--- a/src/WarcraftLegacies.Source/Factions/Warsong/Quests/QuestSubdueOgres.cs
+++ b/src/WarcraftLegacies.Source/Factions/Warsong/Quests/QuestSubdueOgres.cs
@@ -46,13 +46,13 @@ public sealed class QuestSubdueOgres : QuestData
 
   protected override string RewardDescription => Loc.Format(
     "Gain control of Stonemaul, {removeUnit}s' are upgraded to {addUnit}s' and unlock the ability to train {ogreMagi}s. Alternatively, earn {gold} gold and up to {experience} experience points, shared among all your heroes—the fewer heroes you control, the less experience each receives. Additionally, enhance both {blademaster}s' and {korkronElite}s' attack damage by 10, movement speed by 20 and hit points by 250.",
-    ("{removeUnit}", Loc.Get(GetObjectName(SubdueRemoveUnit))),
-    ("{addUnit}", Loc.Get(GetObjectName(SubdueAddUnit))),
-    ("{ogreMagi}", Loc.Get(GetObjectName(UNIT_N08O_OGRE_MAGI_WARSONG))),
+    ("{removeUnit}", GetObjectName(SubdueRemoveUnit)),
+    ("{addUnit}", GetObjectName(SubdueAddUnit)),
+    ("{ogreMagi}", GetObjectName(UNIT_N08O_OGRE_MAGI_WARSONG)),
     ("{gold}", PillageGoldReward.ToString()),
     ("{experience}", PillageExperienceReward.ToString()),
-    ("{blademaster}", Loc.Get(GetObjectName(UNIT_O00G_BLADEMASTER_WARSONG))),
-    ("{korkronElite}", Loc.Get(GetObjectName(UNIT_N03F_KOR_KRON_ELITE_WARSONG_ELITE))));
+    ("{blademaster}", GetObjectName(UNIT_O00G_BLADEMASTER_WARSONG)),
+    ("{korkronElite}", GetObjectName(UNIT_N03F_KOR_KRON_ELITE_WARSONG_ELITE)));
 
   protected override void OnComplete(Faction completingFaction)
   {

--- a/src/WarcraftLegacies.Source/Factions/Warsong/Quests/QuestSubdueTauren.cs
+++ b/src/WarcraftLegacies.Source/Factions/Warsong/Quests/QuestSubdueTauren.cs
@@ -40,9 +40,9 @@ public sealed class QuestSubdueTauren : QuestData
   /// <inheritdoc/>
   protected override string RewardDescription => Loc.Format(
     "Control of Thunder Bluff and the ability to train {kodo}s' from {beastiary} or gain the artifact {totem}, {gold} gold and {experience} experience points, shared across all your heroes—the fewer heroes you control, the less experience each receives.",
-    ("{kodo}", Loc.Get(GetObjectName(UNIT_OKOD_KODO_BEAST_WARSONG))),
-    ("{beastiary}", Loc.Get(GetObjectName(UNIT_O02Q_BEASTIARY_WARSONG_SPECIALIST))),
-    ("{totem}", Loc.Get(GetObjectName(ITEM_I00L_BLOODHOOF_TOTEM))),
+    ("{kodo}", GetObjectName(UNIT_OKOD_KODO_BEAST_WARSONG)),
+    ("{beastiary}", GetObjectName(UNIT_O02Q_BEASTIARY_WARSONG_SPECIALIST)),
+    ("{totem}", GetObjectName(ITEM_I00L_BLOODHOOF_TOTEM)),
     ("{gold}", PillageGoldReward.ToString()),
     ("{experience}", PillageExperienceReward.ToString()));
 

--- a/src/WarcraftLegacies.Source/Factions/Warsong/Quests/QuestSubdueTrolls.cs
+++ b/src/WarcraftLegacies.Source/Factions/Warsong/Quests/QuestSubdueTrolls.cs
@@ -46,13 +46,13 @@ public sealed class QuestSubdueTrolls : QuestData
 
   protected override string RewardDescription => Loc.Format(
     "Gain control of Echo Isles, {removeUnit}s are upgraded to {addUnit}s and learn to train {shadowpriest}s. Alternatively, earn {gold} gold and up to {experience} experience points, shared among all your heroes—the fewer heroes you control, the less experience each receives. Additionally, enhance both {blademaster}s' and {korkronElite}s' maximum mana by 250 and mana regeneration by 50%.",
-    ("{removeUnit}", Loc.Get(GetObjectName(SubdueRemoveUnit))),
-    ("{addUnit}", Loc.Get(GetObjectName(SubdueAddUnit))),
-    ("{shadowpriest}", Loc.Get(GetObjectName(UNIT_N08E_SHADOWPRIEST_WARSONG))),
+    ("{removeUnit}", GetObjectName(SubdueRemoveUnit)),
+    ("{addUnit}", GetObjectName(SubdueAddUnit)),
+    ("{shadowpriest}", GetObjectName(UNIT_N08E_SHADOWPRIEST_WARSONG)),
     ("{gold}", PillageGoldReward.ToString()),
     ("{experience}", PillageExperienceReward.ToString()),
-    ("{blademaster}", Loc.Get(GetObjectName(UNIT_O00G_BLADEMASTER_WARSONG))),
-    ("{korkronElite}", Loc.Get(GetObjectName(UNIT_N03F_KOR_KRON_ELITE_WARSONG_ELITE))));
+    ("{blademaster}", GetObjectName(UNIT_O00G_BLADEMASTER_WARSONG)),
+    ("{korkronElite}", GetObjectName(UNIT_N03F_KOR_KRON_ELITE_WARSONG_ELITE)));
 
   protected override void OnComplete(Faction completingFaction)
   {

--- a/src/WarcraftLegacies.Source/Objectives/UnitBased/ObjectiveResearch.cs
+++ b/src/WarcraftLegacies.Source/Objectives/UnitBased/ObjectiveResearch.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using MacroTools.Localization;
 using MacroTools.Quests;
 using MacroTools.Utils;
 using WCSharp.Events;
@@ -20,8 +19,8 @@ public sealed class ObjectiveResearch : Objective
   {
     SetDescription(
       structureIsProperNoun ? "Research {research} from {structure}" : "Research {research} from the {structure}",
-      ("{research}", Loc.Get(GetObjectName(researchId))),
-      ("{structure}", Loc.Get(GetObjectName(structureId))));
+      ("{research}", GetObjectName(researchId)),
+      ("{structure}", GetObjectName(structureId)));
     PlayerUnitEvents.Register(ResearchEvent.IsFinished, OnAnyResearch, researchId);
   }
 


### PR DESCRIPTION
`GetObjectName` already returns the localized name of the object. Use the value as-is instead. We lose some translated objects (and gain some), but these should have been translated using the native `wts` instead