### PR TITLE
refactor: simplify Loc.Format token substitution

### DIFF
--- a/src/MacroTools/Localization/Loc.cs
+++ b/src/MacroTools/Localization/Loc.cs
@@ -2405,8 +2405,10 @@ public static class Loc
     ["zh"] = _chinese
   };
 
-  public static string Get(string english) =>
-    Get(english, player.LocalPlayer.GetPlayerData().PlayerSettings.Language ?? GetSystemLanguage());
+  public static string Get(string english)
+  {
+    return Get(english, GetLanguage());
+  }
 
   public static string Get(string english, string? language)
   {
@@ -2420,40 +2422,30 @@ public static class Loc
     return english;
   }
 
+  public static string GetLanguage()
+  {
+    return player.LocalPlayer.GetPlayerData().PlayerSettings.Language ?? GetSystemLanguage();
+  }
+
   public static string GetSystemLanguage()
   {
     var locale = BlzGetLocale();
     return locale.StartsWith("es") ? "es" : locale.StartsWith("zh") ? "zh" : "en";
   }
 
-
   public static string Format(string english, params (string Token, string Value)[] args)
   {
-    var template = Get(english);
+    return Format(english, GetLanguage(), args);
+  }
+
+  public static string Format(string english, string? language, params (string Token, string Value)[] args)
+  {
+    var template = Get(english, language);
     foreach (var (token, value) in args)
     {
-      template = ReplaceLiteral(template, token, Get(value));
+      template = template.Replace(token, Get(value, language));
     }
 
     return template;
-  }
-
-  private static string ReplaceLiteral(string source, string oldValue, string newValue)
-  {
-    var result = "";
-    var searchStart = 0;
-    while (true)
-    {
-      var index = source.IndexOf(oldValue, searchStart);
-      if (index < 0)
-      {
-        result += source.Substring(searchStart);
-        return result;
-      }
-
-      result += source.Substring(searchStart, index - searchStart);
-      result += newValue;
-      searchStart = index + oldValue.Length;
-    }
   }
 }

--- a/test/MacroTools.Tests/Localization/LocTests.cs
+++ b/test/MacroTools.Tests/Localization/LocTests.cs
@@ -1,0 +1,78 @@
+﻿using MacroTools.Localization;
+
+namespace MacroTools.Tests.Localization;
+
+public sealed class LocTests
+{
+  [Fact]
+  public void Get_TranslationExists_ReturnsTranslatedText()
+  {
+    // Arrange
+
+    // Act
+    var result = Loc.Get("Completed", "es");
+
+    // Assert
+    Assert.Equal("Completado", result);
+  }
+
+  [Fact]
+  public void Get_NoTranslationForLanguage_ReturnsEnglishFallback()
+  {
+    // Arrange
+
+    // Act
+    var result = Loc.Get("Completed", "zh");
+
+    // Assert
+    Assert.Equal("Completed", result);
+  }
+
+  [Fact]
+  public void Get_UnknownKey_ReturnsInputUnchanged()
+  {
+    // Arrange
+
+    // Act
+    var result = Loc.Get("Some untranslated string", "es");
+
+    // Assert
+    Assert.Equal("Some untranslated string", result);
+  }
+
+  [Fact]
+  public void Get_NullLanguage_ReturnsEnglishFallback()
+  {
+    // Arrange
+
+    // Act
+    var result = Loc.Get("Completed", null);
+
+    // Assert
+    Assert.Equal("Completed", result);
+  }
+
+  [Fact]
+  public void Format_TranslationExists_SubstitutesLocalizedToken()
+  {
+    // Arrange
+
+    // Act
+    var result = Loc.Format("You have joined {team}.", "es", ("{team}", "Alianza"));
+
+    // Assert
+    Assert.Equal("Te uniste a Alianza.", result);
+  }
+
+  [Fact]
+  public void Format_NoTranslation_SubstitutesIntoEnglishTemplate()
+  {
+    // Arrange
+
+    // Act
+    var result = Loc.Format("You have joined {team}.", null, ("{team}", "Alliance"));
+
+    // Assert
+    Assert.Equal("You have joined Alliance.", result);
+  }
+}


### PR DESCRIPTION
Replace `ReplaceLiteral`'s manual token-replacement loop with `string.Replace`, and extract the local player's resolved language into `Loc.GetLanguage`