### PR TITLE
fix: remove duplicate collision effect on muradin's stormbolt

### DIFF
--- a/src/WarcraftLegacies.Source/Factions/Ironforge/Spells/Stormbolt.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge/Spells/Stormbolt.cs
@@ -126,8 +126,6 @@ internal sealed class Stormbolt : Spell
         return;
       }
 
-      effect.Create(EffectModel, MissileX, MissileY).Dispose();
-
       DummyCasterManager
         .GetGlobalDummyCaster()
         .CastUnit(Caster, StunAbilityId, ORDER_THUNDERBOLT, Level, unit, DummyCastOriginType.Target);


### PR DESCRIPTION
I _think_ that when we implemented this there was no on-hit effect on the "dummy" ability, but when we merged the object data together we ended up with two effects. This removes the duplicate effect from the code