### PR TITLE
fix: avoid mutating collection during iteration

### DIFF
--- a/src/WarcraftLegacies.Source/Factions/Quelthalas/Powers/FontOfPower.cs
+++ b/src/WarcraftLegacies.Source/Factions/Quelthalas/Powers/FontOfPower.cs
@@ -91,7 +91,7 @@ public sealed class FontOfPower : Power
 
     foreach (var objective in _objectives)
     {
-      RemoveObjective(objective);
+      objective.ProgressChanged -= OnObjectiveProgressChanged;
     }
 
     _objectives.Clear();
@@ -158,12 +158,6 @@ public sealed class FontOfPower : Power
     _objectives.Add(objective);
     objective.OnAdd(faction);
     objective.ProgressChanged += OnObjectiveProgressChanged;
-  }
-
-  private void RemoveObjective(Objective objective)
-  {
-    _objectives.Remove(objective);
-    objective.ProgressChanged -= OnObjectiveProgressChanged;
   }
 
   private void OnObjectiveProgressChanged(Objective _) => RefreshIsActive();

--- a/src/WarcraftLegacies.Source/Shared/Powers/Immortality.cs
+++ b/src/WarcraftLegacies.Source/Shared/Powers/Immortality.cs
@@ -87,7 +87,7 @@ public sealed class Immortality : Power
   {
     foreach (var objective in _objectives)
     {
-      RemoveObjective(objective);
+      objective.ProgressChanged -= OnObjectiveProgressChanged;
     }
 
     _objectives.Clear();
@@ -113,12 +113,6 @@ public sealed class Immortality : Power
     _objectives.Add(objective);
     objective.OnAdd(faction);
     objective.ProgressChanged += OnObjectiveProgressChanged;
-  }
-
-  private void RemoveObjective(Objective objective)
-  {
-    _objectives.Remove(objective);
-    objective.ProgressChanged -= OnObjectiveProgressChanged;
   }
 
   private void OnObjectiveProgressChanged(Objective _) => RefreshIsActive();


### PR DESCRIPTION
`FontOfPower` and `Immortality` calls `RemoveObjective` while foreach-iterating the same list, throwing `InvalidOperationException`:

```
Failed to execute command: System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
war3map.lua:20256 <- 67 <- 5753 <- 5787 <- 44909 <- 36499 <- 28334 <- 30706 <- 30265 <- 89 <- 30245
```

The call to `_objectives.Clear()` already empties the list, so teardown only needs to unsubscribe the event handler