### PR TITLE
refactor: add CSharpLuaExtensions.GetValueOrDefault

### DIFF
--- a/src/MacroTools/Extensions/CSharpLuaExtensions.cs
+++ b/src/MacroTools/Extensions/CSharpLuaExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace MacroTools.Extensions;
+
+/// <summary>
+/// Shims for .NET APIs that CSharp.lua does not support when transpiling to Lua.
+/// </summary>
+public static class CSharpLuaExtensions
+{
+  /// <inheritdoc cref="CollectionExtensions.GetValueOrDefault{TKey,TValue}(IReadOnlyDictionary{TKey,TValue},TKey)"/>
+  public static TValue? GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key)
+    where TKey : notnull
+  {
+    return dictionary.GetValueOrDefault(key, default!);
+  }
+
+  /// <inheritdoc cref="CollectionExtensions.GetValueOrDefault{TKey,TValue}(IReadOnlyDictionary{TKey,TValue},TKey,TValue)"/>
+  public static TValue GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+    where TKey : notnull
+  {
+    // ReSharper disable once CanSimplifyDictionaryTryGetValueWithGetValueOrDefault
+    return dictionary.TryGetValue(key, out var value) ? value : defaultValue;
+  }
+}

--- a/src/MacroTools/Extensions/PlayerData.cs
+++ b/src/MacroTools/Extensions/PlayerData.cs
@@ -327,7 +327,7 @@ public sealed class PlayerData
     }
   }
 
-  public int GetObjectLimit(int id) => _objectLimits.TryGetValue(id, out var limit) ? limit : 0;
+  public int GetObjectLimit(int id) => _objectLimits.GetValueOrDefault(id);
 
   public void SetObjectLimit(int id, int limit)
   {

--- a/src/MacroTools/Factions/Faction.cs
+++ b/src/MacroTools/Factions/Faction.cs
@@ -256,12 +256,7 @@ public abstract class Faction
   /// <param name="whichObject">The object ID of a unit, building, or research.</param>
   public int GetObjectLimit(int whichObject)
   {
-    if (_objectLimits.TryGetValue(whichObject, out var limit))
-    {
-      return limit;
-    }
-
-    return 0;
+    return _objectLimits.GetValueOrDefault(whichObject);
   }
 
   /// <summary>
@@ -367,7 +362,7 @@ public abstract class Faction
     return questData;
   }
 
-  public int GetObjectLevel(int obj) => _objectLevels.TryGetValue(obj, out var objectLevel) ? objectLevel : 0;
+  public int GetObjectLevel(int obj) => _objectLevels.GetValueOrDefault(obj);
 
   /// <summary>Sets the current level of a particular research for the <see cref="Faction"/>.</summary>
   public void SetObjectLevel(int obj, int level)

--- a/src/MacroTools/Factions/FactionColorManager.cs
+++ b/src/MacroTools/Factions/FactionColorManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using MacroTools.Extensions;
 
 namespace MacroTools.Factions;
 
@@ -34,7 +35,5 @@ public static class ColorManager
   }
 
   public static string GetColorHexCode(playercolor color) =>
-    _colorHexMap.TryGetValue(color, out var value)
-      ? value
-      : "|cff4f5055"; // Default to Coal if no colors can be found freely available.
+    _colorHexMap.GetValueOrDefault(color, "|cff4f5055"); // Default to Coal if no colors can be found freely available.
 }

--- a/src/WarcraftLegacies.Source/Factions/Ironforge/Spells/TitanforgeArtifact.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge/Spells/TitanforgeArtifact.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using MacroTools.Artifacts;
+using MacroTools.Extensions;
 using MacroTools.Spells;
 using WCSharp.Shared.Data;
 
@@ -52,10 +53,7 @@ public sealed class TitanForgeArtifact : Spell
 
   private bool TryTitanforgeArtifact(Artifact artifact)
   {
-    if (!UniqueTitanforgedAbilitiesByItemTypeId.TryGetValue(artifact.Item.TypeId, out var titanforgedAbility))
-    {
-      titanforgedAbility = DefaultTitanforgedAbility;
-    }
+    var titanforgedAbility = UniqueTitanforgedAbilitiesByItemTypeId.GetValueOrDefault(artifact.Item.TypeId, DefaultTitanforgedAbility);
 
     if (artifact.Item.GetAbility(titanforgedAbility) != null)
     {


### PR DESCRIPTION
Add `MacroTools.Extensions.CSharpLuaExtensions` as a place for workarounds around .NET APIs unsupported by CSharp.lua, and simplify existing manual `TryGetValue` lookups to use its `GetValueOrDefault` shim

Needed by https://github.com/AzerothWarsLR/WarcraftLegacies/pull/4089