### PR TITLE
refactor: remove redundant player settings defaults

### DIFF
--- a/src/MacroTools/Save/PlayerSettings.cs
+++ b/src/MacroTools/Save/PlayerSettings.cs
@@ -5,11 +5,11 @@ namespace MacroTools.Save;
 
 public sealed class PlayerSettings : Saveable
 {
-  private int? _camDistance;
+  private int _camDistance = 2400;
 
   public int CamDistance
   {
-    get => _camDistance ?? 2400;
+    get => _camDistance;
     set => _camDistance = Math.Clamp(value, 700, 2701);
   }
 

--- a/src/MacroTools/Save/SaveManager.cs
+++ b/src/MacroTools/Save/SaveManager.cs
@@ -50,14 +50,6 @@ public static class SaveManager
   {
     SavesByPlayer[save.GetPlayer()] = save;
 
-    if (loadResult != LoadResult.Success)
-    {
-      save.CamDistance = 2400;
-      save.ShowQuestText = true;
-      save.PlayDialogue = true;
-      save.ShowCaptions = true;
-    }
-
     if (save.GetPlayer() == player.LocalPlayer)
     {
       if (!save.LanguageIsManual)
@@ -84,9 +76,6 @@ public static class SaveManager
       }
     }
     save.GetPlayer().ApplyCameraField(CAMERA_FIELD_TARGET_DISTANCE, save.CamDistance, 1);
-    save.GetPlayer().GetPlayerSettings().ShowQuestText = save.ShowQuestText;
-    save.GetPlayer().GetPlayerSettings().PlayDialogue = save.PlayDialogue;
-    save.GetPlayer().GetPlayerSettings().ShowCaptions = save.ShowCaptions;
 
     if (loadResult == LoadResult.FailedHash)
     {


### PR DESCRIPTION
Deserialization always builds a fresh instance via `Activator.CreateInstance` and only overwrites properties present in the save data, so per-field defaults already apply on load failure and on missing/legacy fields