### PR TITLE
fix: correct Thunder Crack's target filter, debuff duration, and tooltip

### DIFF
--- a/mapdata/WarcraftLegacies/AbilityData/TP51.json
+++ b/mapdata/WarcraftLegacies/AbilityData/TP51.json
@@ -78,7 +78,7 @@
     {
       "Id": "arut",
       "Type": 3,
-      "Value": "Slams the ground, dealing damage to and slowing the movement speed and attack rate of nearby enemy land units. Also reduces their armor for a short duration.\r\n|n|cffffcc00Level 1|r - \u003CAHtc,DataA1\u003E damage, \u003CAHtc,DataC1,%\u003E% move, \u003CAHtc,DataD1,%\u003E% attack, -3 armor.\r\n|n|cffffcc00Level 2|r - \u003CAHtc,DataA2\u003E damage, \u003CAHtc,DataC2,%\u003E% move, \u003CAHtc,DataD2,%\u003E% attack, -5 armor.\r\n|n|cffffcc00Level 3|r - \u003CAHtc,DataA3\u003E damage, \u003CAHtc,DataC3,%\u003E% move, \u003CAHtc,DataD3,%\u003E% attack, -7 armor.\r\n|n|cffffcc00Level 4|r - \u003CAHtc,DataA4\u003E damage, \u003CAHtc,DataC4,%\u003E% move, \u003CAHtc,DataD4,%\u003E% attack, -9 armor."
+      "Value": "Slams the ground, dealing damage to and slowing the movement speed and attack rate of nearby enemy land units. Also reduces their armor for a short duration.|n|n|cffffcc00Level 1|r - \u003CAHtc,DataA1\u003E damage, \u003CAHtc,DataC1,%\u003E% move, \u003CAHtc,DataD1,%\u003E% attack, -3 armor for \u003CTP51,Dur1,.\u003E (\u003CTP51,HeroDur1,.\u003E) seconds.|n|cffffcc00Level 2|r - \u003CAHtc,DataA2\u003E damage, \u003CAHtc,DataC2,%\u003E% move, \u003CAHtc,DataD2,%\u003E% attack, -5 armor for \u003CTP51,Dur2,.\u003E (\u003CTP51,HeroDur2,.\u003E) seconds.|n|cffffcc00Level 3|r - \u003CAHtc,DataA3\u003E damage, \u003CAHtc,DataC3,%\u003E% move, \u003CAHtc,DataD3,%\u003E% attack, -7 armor for \u003CTP51,Dur3,.\u003E (\u003CTP51,HeroDur3,.\u003E) seconds.|n|cffffcc00Level 4|r - \u003CAHtc,DataA4\u003E damage, \u003CAHtc,DataC4,%\u003E% move, \u003CAHtc,DataD4,%\u003E% attack, -9 armor for \u003CTP51,Dur4,.\u003E (\u003CTP51,HeroDur4,.\u003E) seconds."
     },
     {
       "Level": 1,
@@ -108,25 +108,25 @@
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
-      "Value": "Slams the ground, dealing \u003CAHtc,DataA1\u003E damage to nearby enemy land units and slowing their movement by \u003CAHtc,DataC1,%\u003E% and attack rate by \u003CAHtc,DataD1,%\u003E%. Also reduces their armor by 3.\r\n"
+      "Value": "Slams the ground, dealing \u003CAHtc,DataA1\u003E damage to nearby enemy land units and slowing their movement by \u003CAHtc,DataC1,%\u003E% and attack rate by \u003CAHtc,DataD1,%\u003E%. Also reduces their armor by 3 for \u003CTP51,Dur1,.\u003E (\u003CTP51,HeroDur1,.\u003E) seconds."
     },
     {
       "Level": 2,
       "Id": "aub1",
       "Type": 3,
-      "Value": "Slams the ground, dealing \u003CAHtc,DataA2\u003E damage to nearby enemy land units and slowing their movement by \u003CAHtc,DataC2,%\u003E% and attack rate by \u003CAHtc,DataD2,%\u003E%. Also reduces their armor by 5.\r\n"
+      "Value": "Slams the ground, dealing \u003CAHtc,DataA2\u003E damage to nearby enemy land units and slowing their movement by \u003CAHtc,DataC2,%\u003E% and attack rate by \u003CAHtc,DataD2,%\u003E%. Also reduces their armor by 5 for \u003CTP51,Dur2,.\u003E (\u003CTP51,HeroDur2,.\u003E) seconds."
     },
     {
       "Level": 3,
       "Id": "aub1",
       "Type": 3,
-      "Value": "Slams the ground, dealing \u003CAHtc,DataA3\u003E damage to nearby enemy land units and slowing their movement by \u003CAHtc,DataC3,%\u003E% and attack rate by \u003CAHtc,DataD3,%\u003E%. Also reduces their armor by 7.\r\n"
+      "Value": "Slams the ground, dealing \u003CAHtc,DataA3\u003E damage to nearby enemy land units and slowing their movement by \u003CAHtc,DataC3,%\u003E% and attack rate by \u003CAHtc,DataD3,%\u003E%. Also reduces their armor by 7 for \u003CTP51,Dur3,.\u003E (\u003CTP51,HeroDur3,.\u003E) seconds."
     },
     {
       "Level": 4,
       "Id": "aub1",
       "Type": 3,
-      "Value": "Slams the ground, dealing \u003CAHtc,DataA4\u003E damage to nearby enemy land units and slowing their movement by \u003CAHtc,DataC4,%\u003E% and attack rate by \u003CAHtc,DataD4,%\u003E%. Also reduces their armor by 9."
+      "Value": "Slams the ground, dealing \u003CAHtc,DataA4\u003E damage to nearby enemy land units and slowing their movement by \u003CAHtc,DataC4,%\u003E% and attack rate by \u003CAHtc,DataD4,%\u003E%. Also reduces their armor by 9 for \u003CTP51,Dur4,.\u003E (\u003CTP51,HeroDur4,.\u003E) seconds."
     },
     {
       "Id": "anam",

--- a/src/WarcraftLegacies.Source/Factions/Ironforge/Spells/ThunderCrack/ThunderCrack.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge/Spells/ThunderCrack/ThunderCrack.cs
@@ -9,8 +9,6 @@ namespace WarcraftLegacies.Source.Factions.Ironforge.Spells.ThunderCrack;
 
 public sealed class ThunderCrack : Spell
 {
-  public float DebuffDuration { get; init; } = 3f;
-
   public ThunderCrack(int id) : base(id)
   {
   }
@@ -18,11 +16,14 @@ public sealed class ThunderCrack : Spell
   public override void OnCast(unit caster, unit target, Point targetPoint)
   {
     var level = GetAbilityLevel(caster);
+    var index = level - 1;
     var ability = caster.GetAbility(Id);
-    var radius = ability.GetAreaOfEffect_aare(level - 1);
+    var radius = ability.GetAreaOfEffect_aare(index);
+    var durationNormal = ability.GetDurationNormal_adur(index);
+    var durationHero = ability.GetDurationHero_ahdu(index);
 
     var enemies = GlobalGroup.EnumUnitsInRange(caster.GetPosition(), radius)
-      .Where(enemy => CastFilters.IsTargetEnemyAliveAndGroundUnits(caster, enemy))
+      .Where(enemy => CastFilters.IsTargetEnemyAliveAndGroundUnits(caster, enemy) && !enemy.IsUnitType(unittype.MagicImmune))
       .ToList();
 
     foreach (var enemy in enemies)
@@ -30,7 +31,7 @@ public sealed class ThunderCrack : Spell
       BuffSystem.Add(new ThunderCrackBuff(caster, enemy, level)
       {
         Active = true,
-        Duration = DebuffDuration,
+        Duration = enemy.IsUnitType(unittype.Hero) ? durationHero : durationNormal,
         IsBeneficial = false
       }, StackBehaviour.Stack);
     }


### PR DESCRIPTION
* Filters magic-immune enemies from the armor debuff
* Syncs Thunder Crack's armor debuff duration with its native ability data
* Updates the tooltip to show the per-level/hero duration, and drops redundant newlines that were doubling up line breaks between levels