### PR TITLE
fix: exclude primary target from tentacle attack

### DIFF
--- a/src/WarcraftLegacies.Source/Shared/UnitTraits/MassiveAttack/MassiveAttackProjectile.cs
+++ b/src/WarcraftLegacies.Source/Shared/UnitTraits/MassiveAttack/MassiveAttackProjectile.cs
@@ -30,7 +30,7 @@ public sealed class MassiveAttackProjectile : BasicMissile
 
   public override void OnCollision(unit unit)
   {
-    if (!IsValidTarget(Caster, unit))
+    if (!IsValidTarget(unit, Caster))
     {
       return;
     }
@@ -43,6 +43,6 @@ public sealed class MassiveAttackProjectile : BasicMissile
     target.Alive &&
     !target.IsUnitType(unittype.Structure) &&
     !target.IsUnitType(unittype.Ancient) &&
-    !caster.Owner.IsAlly(target.Owner)
-    | Hits.Contains(target);
+    !caster.Owner.IsAlly(target.Owner) &&
+    !Hits.Contains(target);
 }


### PR DESCRIPTION
cthun tentacles generate a wave when they attack

this wave is supposed to ignore the first target, which received the damage already from the attack

so effectively the tentacles had a bugged double damage on primary target

the code issue is small: `IsValidTarget` expects (unit, Caster) arguments but is called with (Caster, unit), and there's a wrong boolean condition: a target valid if **it's not** in the list of `Hits`