### PR TITLE
perf: move unit-target dummy casters directly

### DIFF
--- a/src/MacroTools/DummyCasters/GlobalDummyCaster.cs
+++ b/src/MacroTools/DummyCasters/GlobalDummyCaster.cs
@@ -18,7 +18,8 @@ public sealed class GlobalDummyCaster
     var originPoint = originType == DummyCastOriginType.Caster ? caster.GetPosition() : target.GetPosition();
     var owningPlayer = caster.Owner;
     _unit.SetOwner(owningPlayer);
-    _unit.SetPosition(originPoint.X, originPoint.Y);
+    _unit.X = originPoint.X;
+    _unit.Y = originPoint.Y;
     _unit.AddAbility(abilId);
     _unit.SetAbilityLevel(abilId, level);
 


### PR DESCRIPTION
SetPosition was being used to move the flying, zero-collision global dummy before every unit-target cast. this performs general positioning/pathing checks that the dummy doesn't need

using direct X/Y positioning reduced the movement cost for 200 targets from ~23ms to ~0.4ms, bringing a MassAny cast on 200 units from ~54ms to ~30ms

tested ingame across repeated 200-target Mass Frost Armor casts, with all 200 targets affected every time