### PR TITLE
fix: register Vertical Wooden Gate as a UnitType

### DIFF
--- a/src/WarcraftLegacies.Source/Setup/UnitTypeSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/UnitTypeSetup.cs
@@ -142,6 +142,21 @@ public static class UnitTypeSetup
     {
       NeverDelete = true
     });
+
+    UnitType.Register(new UnitType(UNIT_H005_VERTICAL_WOODEN_GATE_GATE_OPEN)
+    {
+      NeverDelete = true
+    });
+
+    UnitType.Register(new UnitType(UNIT_H00B_VERTICAL_WOODEN_GATE_GATE_CLOSED)
+    {
+      NeverDelete = true
+    });
+
+    UnitType.Register(new UnitType(UNIT_H009_VERTICAL_WOODEN_GATE_GATE_DEAD)
+    {
+      NeverDelete = true
+    });
   }
 
   private static void SetupFountainOfHealth()


### PR DESCRIPTION
Fixes:

```
System.InvalidOperationException: Vertical Wooden Gate doesn't have a registered UnitType.
war3map.lua:20256 <- 67 <- 91518 <- 36825 <- 93847 <- 93812 <- 37349 <- 36798 <- 29350 <- 89 <- 29349
```