### PR TITLE
fix: only replace starting units owned by the picking player

### DIFF
--- a/src/MacroTools/Factions/Choices/FactionChoiceDialogPresenter.cs
+++ b/src/MacroTools/Factions/Choices/FactionChoiceDialogPresenter.cs
@@ -35,7 +35,7 @@ public sealed class FactionChoiceDialogPresenter : ChoiceDialogPresenter<Faction
   private static void ReplaceStartingUnitsWithFactionEquivalents(player pickingPlayer, FactionChoice choice,
     Faction pickedFaction)
   {
-    var startingUnits = GlobalGroup.EnumUnitsInRect(choice.StartingArea);
+    var startingUnits = GlobalGroup.EnumUnitsInRect(choice.StartingArea).Where(u => u.Owner == pickingPlayer);
 
     foreach (var unit in startingUnits)
     {


### PR DESCRIPTION
Fixes:

```
System.InvalidOperationException: Satyr Soulstealer doesn't have a registered UnitType.
war3map.lua:20256 <- 67 <- 91678 <- 36946 <- 36934 <- 29491 <- 89 <- 29490
```