### PR TITLE
Technopig/lock south kalimdor

### DIFF
--- a/mapdata/WarcraftLegacies/Regions/SouthKalimdor1.json
+++ b/mapdata/WarcraftLegacies/Regions/SouthKalimdor1.json
@@ -1,0 +1,16 @@
+{
+  "Left": -24352,
+  "Bottom": -20704,
+  "Right": -7744,
+  "Top": -12576,
+  "Name": "SouthKalimdor1",
+  "CreationNumber": 213,
+  "WeatherType": 0,
+  "AmbientSound": "",
+  "Color": {
+    "R": 0,
+    "G": 0,
+    "B": 0,
+    "A": 255
+  }
+}

--- a/mapdata/WarcraftLegacies/Regions/SouthKalimdor2.json
+++ b/mapdata/WarcraftLegacies/Regions/SouthKalimdor2.json
@@ -1,0 +1,16 @@
+{
+  "Left": -17408,
+  "Bottom": -12576,
+  "Right": -14080,
+  "Top": -8320,
+  "Name": "SouthKalimdor2",
+  "CreationNumber": 223,
+  "WeatherType": 0,
+  "AmbientSound": "",
+  "Color": {
+    "R": 0,
+    "G": 0,
+    "B": 0,
+    "A": 255
+  }
+}

--- a/mapdata/WarcraftLegacies/Regions/SouthKalimdor3.json
+++ b/mapdata/WarcraftLegacies/Regions/SouthKalimdor3.json
@@ -1,0 +1,16 @@
+{
+  "Left": -23680,
+  "Bottom": -12416,
+  "Right": -17408,
+  "Top": -5568,
+  "Name": "SouthKalimdor3",
+  "CreationNumber": 222,
+  "WeatherType": 0,
+  "AmbientSound": "",
+  "Color": {
+    "R": 0,
+    "G": 0,
+    "B": 0,
+    "A": 255
+  }
+}

--- a/src/WarcraftLegacies.Source/GameLogic/SouthKalimdorGuard/SouthKalimdorGuardSystem.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/SouthKalimdorGuard/SouthKalimdorGuardSystem.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using System.Linq;
+using MacroTools.Extensions;
+using MacroTools.GameTime;
+using MacroTools.Shores;
+using WCSharp.Shared.Data;
+
+namespace WarcraftLegacies.Source.GameLogic.SouthKalimdorGuard;
+
+/// <summary>
+/// Shoves intruding units back out of Southern Kalimdor until <see cref="UnlockTurn"/>.
+/// </summary>
+public static class SouthKalimdorGuardSystem
+{
+  /// <summary>
+  /// The turn Southern Kalimdor opens up. Also used as the rock wall expiry in <see cref="Setup.RockSetup"/>.
+  /// </summary>
+  public const int UnlockTurn = 15;
+
+  private const float PushBackDistance = 128f;
+  private const float MessageCooldownSeconds = 20f;
+
+  private static readonly Rectangle[] LockedRegions =
+  {
+    Regions.SouthKalimdor1,
+    Regions.SouthKalimdor2,
+    Regions.SouthKalimdor3
+  };
+
+  private static readonly HashSet<player> _recentlyWarned = new();
+
+  public static void Setup()
+  {
+    var splitX = (LockedRegions.Min(region => region.Left) + LockedRegions.Max(region => region.Right)) / 2;
+
+    foreach (var region in LockedRegions)
+    {
+      var enterTrigger = trigger.Create();
+      enterTrigger.RegisterEnterRegion(region.Region);
+      enterTrigger.AddAction(() => OnUnitEntered(region, splitX));
+    }
+  }
+
+  private static void OnUnitEntered(Rectangle region, float splitX)
+  {
+    var triggerUnit = @event.Unit;
+
+    if (GameTimeManager.Turn >= UnlockTurn)
+    {
+      return;
+    }
+
+    var owner = triggerUnit.Owner;
+    if (owner == player.NeutralAggressive || owner == player.NeutralPassive)
+    {
+      return;
+    }
+
+    if (triggerUnit.IsUnitBoat())
+    {
+      return;
+    }
+
+    var entryPosition = triggerUnit.GetPosition();
+    var safePosition = GetPushBackPosition(region, entryPosition);
+    triggerUnit.SetPosition(safePosition.X, safePosition.Y);
+
+    WarnPlayer(owner, entryPosition.X < splitX
+      ? "|cff00ffffNaga raiders control these waters. Your forces are turned back until the mainland is secure.|r"
+      : "|cffcc8800Centaur riders patrol this frontier. Your forces are turned back until the mainland is secure.|r");
+  }
+
+  private static Point GetPushBackPosition(Rectangle region, Point position)
+  {
+    var distanceToLeft = position.X - region.Left;
+    var distanceToRight = region.Right - position.X;
+    var distanceToBottom = position.Y - region.Bottom;
+    var distanceToTop = region.Top - position.Y;
+    var closest = System.Math.Min(System.Math.Min(distanceToLeft, distanceToRight), System.Math.Min(distanceToBottom, distanceToTop));
+
+    var candidate = closest == distanceToLeft ? new Point(region.Left - PushBackDistance, position.Y)
+      : closest == distanceToRight ? new Point(region.Right + PushBackDistance, position.Y)
+      : closest == distanceToBottom ? new Point(position.X, region.Bottom - PushBackDistance)
+      : new Point(position.X, region.Top + PushBackDistance);
+
+    if (IsSafeLandingSpot(candidate))
+    {
+      return candidate;
+    }
+
+    return GetNearestSafeShore(candidate) ?? candidate;
+  }
+
+  /// <summary>
+  /// True if the position is walkable ground and not inside any of the locked regions.
+  /// </summary>
+  private static bool IsSafeLandingSpot(Point position) =>
+    !pathingtype.Walkability.GetPathable(position.X, position.Y) &&
+    !LockedRegions.Any(region => region.Contains(position.X, position.Y));
+
+  private static Point? GetNearestSafeShore(Point position)
+  {
+    Shore? nearest = null;
+    var nearestDistanceSquared = float.MaxValue;
+    foreach (var shore in ShoreManager.GetAllShores())
+    {
+      if (LockedRegions.Any(region => region.Contains(shore.Position.X, shore.Position.Y)))
+      {
+        continue;
+      }
+
+      var deltaX = shore.Position.X - position.X;
+      var deltaY = shore.Position.Y - position.Y;
+      var distanceSquared = deltaX * deltaX + deltaY * deltaY;
+      if (distanceSquared < nearestDistanceSquared)
+      {
+        nearestDistanceSquared = distanceSquared;
+        nearest = shore;
+      }
+    }
+
+    return nearest?.Position;
+  }
+
+  private static void WarnPlayer(player whichPlayer, string message)
+  {
+    if (_recentlyWarned.Contains(whichPlayer))
+    {
+      return;
+    }
+
+    _recentlyWarned.Add(whichPlayer);
+    DisplayTextToPlayer(whichPlayer, 0, 0, message);
+
+    var cooldown = timer.Create();
+    cooldown.Start(MessageCooldownSeconds, false, () =>
+    {
+      _recentlyWarned.Remove(whichPlayer);
+      cooldown.Dispose();
+    });
+  }
+}

--- a/src/WarcraftLegacies.Source/GameLogic/SouthKalimdorGuard/SouthKalimdorGuardSystem.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/SouthKalimdorGuard/SouthKalimdorGuardSystem.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using MacroTools.Extensions;
 using MacroTools.GameTime;
@@ -20,7 +20,7 @@ public static class SouthKalimdorGuardSystem
   private const float PushBackDistance = 128f;
   private const float MessageCooldownSeconds = 20f;
 
-  private static readonly Rectangle[] LockedRegions =
+  private static readonly Rectangle[] _lockedRegions =
   {
     Regions.SouthKalimdor1,
     Regions.SouthKalimdor2,
@@ -31,9 +31,9 @@ public static class SouthKalimdorGuardSystem
 
   public static void Setup()
   {
-    var splitX = (LockedRegions.Min(region => region.Left) + LockedRegions.Max(region => region.Right)) / 2;
+    var splitX = (_lockedRegions.Min(region => region.Left) + _lockedRegions.Max(region => region.Right)) / 2;
 
-    foreach (var region in LockedRegions)
+    foreach (var region in _lockedRegions)
     {
       var enterTrigger = trigger.Create();
       enterTrigger.RegisterEnterRegion(region.Region);
@@ -96,7 +96,7 @@ public static class SouthKalimdorGuardSystem
   /// </summary>
   private static bool IsSafeLandingSpot(Point position) =>
     !pathingtype.Walkability.GetPathable(position.X, position.Y) &&
-    !LockedRegions.Any(region => region.Contains(position.X, position.Y));
+    !_lockedRegions.Any(region => region.Contains(position.X, position.Y));
 
   private static Point? GetNearestSafeShore(Point position)
   {
@@ -104,7 +104,7 @@ public static class SouthKalimdorGuardSystem
     var nearestDistanceSquared = float.MaxValue;
     foreach (var shore in ShoreManager.GetAllShores())
     {
-      if (LockedRegions.Any(region => region.Contains(shore.Position.X, shore.Position.Y)))
+      if (_lockedRegions.Any(region => region.Contains(shore.Position.X, shore.Position.Y)))
       {
         continue;
       }

--- a/src/WarcraftLegacies.Source/Regions.g.cs
+++ b/src/WarcraftLegacies.Source/Regions.g.cs
@@ -280,6 +280,9 @@ public static class Regions
   public static Rectangle SlipstreamTempestOrigin { get; set; } = new Rectangle(-22304f, 6816f, -22112f, 7392f);
   public static Rectangle SlipstreamTempestTarget { get; set; } = new Rectangle(2752f, -21920f, 3200f, -21504f);
   public static Rectangle Solliden_Farmstead { get; set; } = new Rectangle(6400f, 8992f, 7808f, 10592f);
+  public static Rectangle SouthKalimdor1 { get; set; } = new Rectangle(-24352f, -20704f, -7744f, -12576f);
+  public static Rectangle SouthKalimdor2 { get; set; } = new Rectangle(-17408f, -12576f, -14080f, -8320f);
+  public static Rectangle SouthKalimdor3 { get; set; } = new Rectangle(-23680f, -12416f, -17408f, -5568f);
   public static Rectangle South_EK_Ships { get; set; } = new Rectangle(7872f, -18240f, 18880f, -12288f);
   public static Rectangle SouthshoreAmbient { get; set; } = new Rectangle(9216f, 1216f, 14176f, 3520f);
   public static Rectangle SouthshoreAmbient2 { get; set; } = new Rectangle(10336f, 3936f, 13568f, 4608f);

--- a/src/WarcraftLegacies.Source/Setup/GameSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/GameSetup.cs
@@ -14,6 +14,7 @@ using WarcraftLegacies.Source.GameLogic.ArtifactBehaviour;
 using WarcraftLegacies.Source.GameLogic.AssistedFollow;
 using WarcraftLegacies.Source.GameLogic.GameEnd;
 using WarcraftLegacies.Source.GameLogic.Mmd;
+using WarcraftLegacies.Source.GameLogic.SouthKalimdorGuard;
 using WarcraftLegacies.Source.GameModes;
 using WarcraftLegacies.Source.Shared;
 using WarcraftLegacies.Source.Testing;
@@ -78,6 +79,7 @@ public static class GameSetup
     };
     gameModeManager.Setup();
     RockSetup.Setup();
+    SouthKalimdorGuardSystem.Setup();
     TurnResearchSetup.Setup();
     ShipyardBanZonesSetup.Setup();
     BlockerSetup.Setup();

--- a/src/WarcraftLegacies.Source/Setup/RockSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/RockSetup.cs
@@ -1,4 +1,5 @@
 ﻿using WarcraftLegacies.Source.GameLogic.Rocks;
+using WarcraftLegacies.Source.GameLogic.SouthKalimdorGuard;
 
 namespace WarcraftLegacies.Source.Setup;
 
@@ -22,5 +23,8 @@ public static class RockSetup
 
     //Bridge Rocks
     RockSystem.Register(new RockGroup(Regions.BridgeAmbient, _rockChunkId, 30));
+
+    RockSystem.Register(new RockGroup(Regions.SouthKalimdor2, _rockChunkId, SouthKalimdorGuardSystem.UnlockTurn));
+    RockSystem.Register(new RockGroup(Regions.SouthKalimdor3, _rockChunkId, SouthKalimdorGuardSystem.UnlockTurn));
   }
 }


### PR DESCRIPTION
South Kalimdor is locked off until turn 15 so no one can rush in and snipe creeps or control points early.                                
                                                                                                                                            
  - The whole area shoves any player unit that wanders in back out, with a message explaining why.                                                                                           
  - Boats and neutral creeps are ignored, so ships can still sail through and existing creep camps aren't touched.                                                                                      
  - Everything opens up automatically at turn 15 with the TBA outpost quests for Orcish Horde and Sentinels. 


<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/85ccf301-994f-4863-a30e-45b08b7a9a08" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/23aa5269-18f4-41da-8e3c-3f648966530a" />


If you attempt to land within the region units are transported to the nearest safe, walkable shore. 
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/149b6ce4-401f-4190-a036-2e0009976f92" />
