### PR TITLE
perf: extra position improv + less object created

### DIFF
--- a/src/MacroTools/DummyCasters/AbilitySpecificDummyCaster.cs
+++ b/src/MacroTools/DummyCasters/AbilitySpecificDummyCaster.cs
@@ -32,7 +32,7 @@ public sealed class AbilitySpecificDummyCaster
 
     if (originType == DummyCastOriginType.Caster)
     {
-      _unit.FacePosition(target.GetPosition());
+      _unit.FacePosition(target.X, target.Y);
     }
 
     _unit.IssueOrder(_abilityOrderId, target);
@@ -56,7 +56,8 @@ public sealed class AbilitySpecificDummyCaster
   {
     var whichPlayer = caster.Owner;
     _unit.SetOwner(whichPlayer);
-    _unit.SetPosition(target.X, target.Y);
+    _unit.X = target.X;
+    _unit.Y = target.Y;
     _unit.AddAbility(_abilityTypeId);
     _unit.SetAbilityLevel(_abilityTypeId, level);
 

--- a/src/MacroTools/DummyCasters/GlobalDummyCaster.cs
+++ b/src/MacroTools/DummyCasters/GlobalDummyCaster.cs
@@ -15,17 +15,24 @@ public sealed class GlobalDummyCaster
   /// </summary>
   public void CastUnit(unit caster, int abilId, int orderId, int level, unit target, DummyCastOriginType originType)
   {
-    var originPoint = originType == DummyCastOriginType.Caster ? caster.GetPosition() : target.GetPosition();
+    if originType == DummyCastOriginType.Caster 
+    {
+      _unit.X = caster.X;
+      _unit.Y = caster.Y;
+    }
+    else
+    {
+      _unit.X = target.X;
+      _unit.Y = target.Y;
+    }
     var owningPlayer = caster.Owner;
     _unit.SetOwner(owningPlayer);
-    _unit.X = originPoint.X;
-    _unit.Y = originPoint.Y;
     _unit.AddAbility(abilId);
     _unit.SetAbilityLevel(abilId, level);
 
     if (originType == DummyCastOriginType.Caster)
     {
-      _unit.FacePosition(target.GetPosition());
+      _unit.FacePosition(target.X, target.Y);
     }
 
     _unit.IssueOrder(orderId, target);
@@ -39,7 +46,8 @@ public sealed class GlobalDummyCaster
   {
     var owningPlayer = caster.Owner;
     _unit.SetOwner(owningPlayer);
-    _unit.SetPosition(caster.X, caster.Y);
+    _unit.X = caster.X;
+    _unit.Y = caster.Y;
     _unit.AddAbility(abilId);
     _unit.SetAbilityLevel(abilId, level);
 
@@ -62,7 +70,8 @@ public sealed class GlobalDummyCaster
   public void CastPoint(player whichPlayer, int abilId, int orderId, int level, Point target)
   {
     _unit.SetOwner(whichPlayer);
-    _unit.SetPosition(target.X, target.Y);
+    _unit.X = target.X;
+    _unit.Y = target.Y;
     _unit.AddAbility(abilId);
     _unit.SetAbilityLevel(abilId, level);
     _unit.IssueOrder(orderId, target.X, target.Y);
@@ -73,11 +82,12 @@ public sealed class GlobalDummyCaster
     var whichPlayer = caster.Owner;
 
     _unit.SetOwner(whichPlayer);
-    _unit.SetPosition(caster.X, caster.Y);
+    _unit.X = caster.X;
+    _unit.Y = caster.Y;
     _unit.AddAbility(abilId);
     _unit.SetAbilityLevel(abilId, level);
 
-    _unit.FacePosition(new Point(x, y));
+    _unit.FacePosition(x, y);
     _unit.IssueOrder(orderId, x, y);
 
     _unit.RemoveAbility(abilId);

--- a/src/MacroTools/Extensions/UnitExtensions.cs
+++ b/src/MacroTools/Extensions/UnitExtensions.cs
@@ -367,9 +367,9 @@ public static class UnitExtensions
   /// <summary>
   /// Turns the unit to face a particular position.
   /// </summary>
-  public static void FacePosition(this unit whichUnit, Point targetPoint)
+  public static void FacePosition(this unit whichUnit, float targetX, float targetY)
   {
-    var facing = WCSharp.Shared.Util.AngleBetweenPoints(whichUnit.X, whichUnit.Y, targetPoint.X, targetPoint.Y);
+    var facing = WCSharp.Shared.Util.AngleBetweenPoints(whichUnit.X, whichUnit.Y, targetX, targetY);
     whichUnit.Facing = facing;
   }
 


### PR DESCRIPTION
Small fix to dummy cast, similar to previous #4099 

there were other casts using SetPosition instead of direct setting

i also remove the amount of object creation, mainly creating points when floats should simply be passed around.

1. in faceposition, a point should not be created and destructed again

2. same for originPoint: instead of creating an object (heap allocation = bad), directly set the x/y